### PR TITLE
[RHBA-497] Allow bpmsuite and rhba products

### DIFF
--- a/os.bpmsuite.businesscentral/added/launch/bpmsuite-businesscentral.sh
+++ b/os.bpmsuite.businesscentral/added/launch/bpmsuite-businesscentral.sh
@@ -108,7 +108,7 @@ function configure_guvnor_settings() {
 function configure_misc_security() {
     add_management_interface_realm
     # KieLoginModule breaks Decision Central; it needs to be added only for Business Central & Business Central Monitoring
-    if [ "$JBOSS_PRODUCT" = "bpmsuite-businesscentral" ] || [ "$JBOSS_PRODUCT" = "bpmsuite-businesscentral-monitoring" ]; then
+    if [[ $JBOSS_PRODUCT =~ (rhba|bpmsuite)\-businesscentral(\-monitoring)? ]]; then
         configure_login_modules "org.kie.security.jaas.KieLoginModule" "optional" "deployment.ROOT.war"
     fi
 }


### PR DESCRIPTION
Fixes [RHBA-497](https://issues.jboss.org/browse/RHBA-497) which affects the businesscentral configuration script that no longer adds the KieLoginModule module  as the JBOSS_PRODUCT was renamed to rhba-businesscentral

Using a regular expression to match the following products
* rhba-businesscentral
* rhba-businesscentral-monitoring
* jbpmsuite-businesscentral
* jbpmsuite-businesscentral-monitoring
