### PR TITLE
[RHBA-530] Removed reference to missing dependency

### DIFF
--- a/os.bpmsuite.smartrouter/added/launch/bpmsuite-smartrouter.sh
+++ b/os.bpmsuite.smartrouter/added/launch/bpmsuite-smartrouter.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "/opt/${JBOSS_PRODUCT}/launch/launch-common.sh"
+source "${LAUNCH_DIR}/launch-common.sh"
 
 function prepareEnv() {
     # please keep these in alphabetical order

--- a/os.bpmsuite.smartrouter/added/launch/configure.sh
+++ b/os.bpmsuite.smartrouter/added/launch/configure.sh
@@ -47,7 +47,7 @@
 # type entries, which should only be processed once.
 #
 
-source $JBOSS_HOME/bin/launch/logging.sh
+source ${LAUNCH_DIR}/logging.sh
 
 # clear functions from any previous module
 function prepareModule() {

--- a/os.bpmsuite.smartrouter/added/openshift-launch.sh
+++ b/os.bpmsuite.smartrouter/added/openshift-launch.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Openshift BPMS Smart Router launch script
 
-source $JBOSS_HOME/bin/launch/logging.sh
+source ${LAUNCH_DIR}/logging.sh
 
 if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     set -x
@@ -9,10 +9,10 @@ if [ "${SCRIPT_DEBUG}" = "true" ] ; then
 fi
 
 CONFIGURE_SCRIPTS=(
-  /opt/${JBOSS_PRODUCT}/launch/bpmsuite-smartrouter.sh
+  ${LAUNCH_DIR}/bpmsuite-smartrouter.sh
 )
 
-source /opt/${JBOSS_PRODUCT}/launch/configure.sh
+source ${LAUNCH_DIR}/configure.sh
 
 log_info "Running $JBOSS_IMAGE_NAME image, version $PRODUCT_VERSION"
 

--- a/os.bpmsuite.smartrouter/configure.sh
+++ b/os.bpmsuite.smartrouter/configure.sh
@@ -9,8 +9,8 @@ ROUTER_DIR=/opt/${JBOSS_PRODUCT}
 # Add custom launch script and dependent scripts/libraries/snippets
 cp -p ${ADDED_DIR}/openshift-launch.sh ${ROUTER_DIR}/
 
-mkdir -p ${ROUTER_DIR}/launch
-cp -r ${ADDED_DIR}/launch/* ${ROUTER_DIR}/launch
+mkdir -p ${LAUNCH_DIR}
+cp -r ${ADDED_DIR}/launch/* $LAUNCH_DIR
 
 # Necessary to permit running with a randomised UID
 chown -R jboss:root ${ROUTER_DIR}


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/RHBA-530

All the images that extend JBoss EAP include the module `os-logging` which copies under $JBOSS_HOME/bin/launch the logging.sh script that sets the colour each loglevel should be displayed with.

There are two options here:

1. Remove the reference to this script as it doesn't add any big value in a container native image
1. Change where the smartrouter scripts are copied to /opt/rhba-smartrouter/bin set the JBOSS_HOME env variable and import the os-logging module

I have opted for the first option. It is cleaner and adds less dependencies to EAP's inner structure.