### PR TITLE
[CLOUD-2410] [KIESRV64] "log_ino" typo in kieserver-pull.sh

### DIFF
--- a/os.kieserver.launch/added/kieserver-pull.sh
+++ b/os.kieserver.launch/added/kieserver-pull.sh
@@ -40,7 +40,7 @@ for (( i=0; i<${KIE_CONTAINER_DEPLOYMENT_COUNT}; i++ )); do
 
     log_info "Attempting to pull dependencies for kjar ${i} with 'mvn ${MAVEN_ARGS_PULL}'"
     log_info "Using MAVEN_OPTS '${MAVEN_OPTS}'"
-    log_ino "Using $(mvn --version)"
+    log_info "Using $(mvn --version)"
 
     # Execute the maven pull of dependencies
     mvn $MAVEN_ARGS_PULL


### PR DESCRIPTION
[CLOUD-2410] [KIESRV64] "log_ino" typo in kieserver-pull.sh
https://issues.jboss.org/browse/CLOUD-2410

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
