### PR TITLE
[RHPAM-796] Persistent smart router configuration to allow HA/restarts

### DIFF
--- a/os.bpmsuite.smartrouter/added/launch/bpmsuite-smartrouter.sh
+++ b/os.bpmsuite.smartrouter/added/launch/bpmsuite-smartrouter.sh
@@ -17,6 +17,8 @@ function prepareEnv() {
     unset KIE_SERVER_ROUTER_PORT
     unset KIE_SERVER_ROUTER_PROTOCOL
     unset KIE_SERVER_ROUTER_URL_EXTERNAL
+    unset KIE_SERVER_ROUTER_REPO
+    unset KIE_SERVER_ROUTER_CONFIG_WATCHER_ENABLED
 }
 
 function configureEnv() {
@@ -49,9 +51,20 @@ function configure_router_state() {
     fi
     JBOSS_BPMSUITE_ARGS="${JBOSS_BPMSUITE_ARGS} -Dorg.kie.server.router.name=${kieServerRouterName}"
 
+    # Potentially allow HA config by watching file system for config changes
+    if [ "x${KIE_SERVER_ROUTER_CONFIG_WATCHER_ENABLED}" != "x" ]; then
+        JBOSS_BPMSUITE_ARGS="${JBOSS_BPMSUITE_ARGS} -Dorg.kie.server.router.config.watcher.enabled=${KIE_SERVER_ROUTER_CONFIG_WATCHER_ENABLED}"
+    fi
+
     # see scripts/os.bpmsuite.smartrouter/configure.sh
     local kieServerRouterRepo="/opt/${JBOSS_PRODUCT}"
-    JBOSS_BPMSUITE_ARGS="${JBOSS_BPMSUITE_ARGS} -Dorg.kie.server.router.repo=${kieServerRouterRepo}"
+
+    # Potentially modify the location of smart router data
+    if [ "x${KIE_SERVER_ROUTER_REPO}" != "x" ]; then
+        JBOSS_BPMSUITE_ARGS="${JBOSS_BPMSUITE_ARGS} -Dorg.kie.server.router.repo=${KIE_SERVER_ROUTER_REPO}"
+    else
+        JBOSS_BPMSUITE_ARGS="${JBOSS_BPMSUITE_ARGS} -Dorg.kie.server.router.repo=${kieServerRouterRepo}"
+    fi
 }
 
 function configure_router_location {

--- a/os.bpmsuite.smartrouter/configure.sh
+++ b/os.bpmsuite.smartrouter/configure.sh
@@ -12,6 +12,9 @@ cp -p ${ADDED_DIR}/openshift-launch.sh ${ROUTER_DIR}/
 mkdir -p ${LAUNCH_DIR}
 cp -r ${ADDED_DIR}/launch/* $LAUNCH_DIR
 
+# Ensure that the local data directory exists
+mkdir -p ${ROUTER_DIR}/data
+
 # Necessary to permit running with a randomised UID
 chown -R jboss:root ${ROUTER_DIR}
 chmod -R 777 ${ROUTER_DIR}


### PR DESCRIPTION
Have Smart Router use persistent configuration to sync state across replicas

https://issues.jboss.org/browse/RHPAM-796

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
