### PR TITLE
[RHPAM-891] maven users created in eap unnecessarily

### DIFF
--- a/tests/features/rhdm/kieserver/rhdm-kieserver.feature
+++ b/tests/features/rhdm/kieserver/rhdm-kieserver.feature
@@ -67,9 +67,8 @@ Feature: RHDM KIE Server configuration tests
 
   Scenario: deploys the hellorules example, then checks if it's deployed.
     Given s2i build https://github.com/jboss-container-images/rhdm-7-openshift-image from quickstarts/hello-rules/hellorules using rhdm70-dev
-      | variable                         | value                                                                                        |
-      | KIE_CONTAINER_DEPLOYMENT         | rhdm-kieserver-hellorules=org.openshift.quickstarts:rhdm-kieserver-hellorules:1.4.0-SNAPSHOT |
-      | KIE_CONTAINER_REDIRECT_ENABLED   | false                                                                                        |
+      | variable                        | value                                                                                        |
+      | KIE_SERVER_CONTAINER_DEPLOYMENT | rhdm-kieserver-hellorules=org.openshift.quickstarts:rhdm-kieserver-hellorules:1.4.0-SNAPSHOT |
     Then container log should contain Container rhdm-kieserver-hellorules
 
   # https://issues.jboss.org/browse/RHPAM-846

--- a/tests/features/rhpam/kieserver/rhpam-kieserver.feature
+++ b/tests/features/rhpam/kieserver/rhpam-kieserver.feature
@@ -66,11 +66,11 @@ Feature: RHPAM KIE Server configuration tests
     Then file /opt/eap/standalone/deployments/node-info.war should exist
 
   Scenario: deploys the library example, then checks if it's deployed.
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from processserver/library using master
-      | variable                         | value                                                                        |
-      | KIE_CONTAINER_DEPLOYMENT         | LibraryContainer=org.openshift.quickstarts:processserver-library:1.4.0.Final |
-      | KIE_CONTAINER_REDIRECT_ENABLED   | false                                                                        |
-    Then container log should contain Container LibraryContainer
+    Given s2i build https://github.com/jboss-container-images/rhpam-7-openshift-image from quickstarts/library-process/library using rhpam70-dev
+      | variable                        | value                                                                                    |
+      | KIE_SERVER_CONTAINER_DEPLOYMENT | rhpam-kieserver-library=org.openshift.quickstarts:rhpam-kieserver-library:1.4.0-SNAPSHOT |
+    Then container log should contain Container rhpam-kieserver-library
+
 
   # https://issues.jboss.org/browse/RHPAM-846
   Scenario: Check jbpm is enabled in RHPAM 7


### PR DESCRIPTION
[RHPAM-891] maven users created in eap unnecessarily
https://issues.jboss.org/browse/RHPAM-891

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
