### PR TITLE
RHPAM-891: Fix missing spaces

### DIFF
--- a/os.bpmsuite.common/added/launch/bpmsuite-security.sh
+++ b/os.bpmsuite.common/added/launch/bpmsuite-security.sh
@@ -108,7 +108,7 @@ function get_kie_server_domain() {
 
 function get_kie_server_bypass_auth_user() {
     local bypass_auth_user=$(echo "${KIE_SERVER_BYPASS_AUTH_USER}" | tr "[:upper:]" "[:lower:]")
-    if [ "x${bypass_auth_user}" != "x"] && [ "${bypass_auth_user}" != "true"]; then
+    if [ "x${bypass_auth_user}" != "x" ] && [ "${bypass_auth_user}" != "true" ]; then
         bypass_auth_user="false"
     fi
     echo "${bypass_auth_user}"


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

Fix for "/opt/eap/bin/launch/bpmsuite-security.sh: line 111: [: missing `]'" issue in Kie server image.
@errantepiphany Please take a look.

https://issues.jboss.org/browse/RHPAM-891

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
