### PR TITLE
[RHPAM-891] maven users created in eap unnecessarily

### DIFF
--- a/os.bpmsuite.executionserver/added/launch/bpmsuite-executionserver.sh
+++ b/os.bpmsuite.executionserver/added/launch/bpmsuite-executionserver.sh
@@ -309,7 +309,8 @@ function configure_server_persistence() {
 }
 
 function configure_server_security() {
-    # add eap user (see bpmsuite-security.sh)
+    # add eap users (see bpmsuite-security.sh)
+    add_kie_admin_user
     add_kie_server_user
     # user/pwd
     JBOSS_BPMSUITE_ARGS="${JBOSS_BPMSUITE_ARGS} -Dorg.kie.server.user=$(get_kie_server_user)"

--- a/tests/features/rhdm/kieserver/rhdm-kieserver.feature
+++ b/tests/features/rhdm/kieserver/rhdm-kieserver.feature
@@ -14,8 +14,8 @@ Feature: RHDM KIE Server configuration tests
   # https://issues.jboss.org/browse/RHPAM-891
   Scenario: Check default users are properly configured
     When container is ready
-    Then file /opt/eap/standalone/configuration/application-users.properties should not contain adminUser
-     And file /opt/eap/standalone/configuration/application-roles.properties should not contain adminUser
+    Then file /opt/eap/standalone/configuration/application-users.properties should contain adminUser=de3155e1927c6976555925dec24a53ac
+     And file /opt/eap/standalone/configuration/application-roles.properties should contain adminUser=kie-server,rest-all,admin,kiemgmt,Administrators
      And file /opt/eap/standalone/configuration/application-users.properties should not contain mavenUser
      And file /opt/eap/standalone/configuration/application-roles.properties should not contain mavenUser
      And file /opt/eap/standalone/configuration/application-users.properties should not contain controllerUser
@@ -35,8 +35,8 @@ Feature: RHDM KIE Server configuration tests
       | KIE_SERVER_CONTROLLER_PWD  | customCtl!0 |
       | KIE_SERVER_USER            | customExe   |
       | KIE_SERVER_PWD             | customExe!0 |
-    Then file /opt/eap/standalone/configuration/application-users.properties should not contain customAdm
-     And file /opt/eap/standalone/configuration/application-roles.properties should not contain customAdm
+    Then file /opt/eap/standalone/configuration/application-users.properties should contain customAdm=05ad559f03f4a06845bf201990f6832f
+     And file /opt/eap/standalone/configuration/application-roles.properties should contain customAdm=kie-server,rest-all,admin,kiemgmt,Administrators
      And file /opt/eap/standalone/configuration/application-users.properties should not contain customMvn
      And file /opt/eap/standalone/configuration/application-roles.properties should not contain customMvn
      And file /opt/eap/standalone/configuration/application-users.properties should not contain customCtl

--- a/tests/features/rhpam/kieserver/rhpam-kieserver.feature
+++ b/tests/features/rhpam/kieserver/rhpam-kieserver.feature
@@ -14,8 +14,8 @@ Feature: RHPAM KIE Server configuration tests
   # https://issues.jboss.org/browse/RHPAM-891
   Scenario: Check default users are properly configured
     When container is ready
-    Then file /opt/eap/standalone/configuration/application-users.properties should not contain adminUser
-     And file /opt/eap/standalone/configuration/application-roles.properties should not contain adminUser
+    Then file /opt/eap/standalone/configuration/application-users.properties should contain adminUser=de3155e1927c6976555925dec24a53ac
+     And file /opt/eap/standalone/configuration/application-roles.properties should contain adminUser=kie-server,rest-all,admin,kiemgmt,Administrators
      And file /opt/eap/standalone/configuration/application-users.properties should not contain mavenUser
      And file /opt/eap/standalone/configuration/application-roles.properties should not contain mavenUser
      And file /opt/eap/standalone/configuration/application-users.properties should not contain controllerUser
@@ -35,8 +35,8 @@ Feature: RHPAM KIE Server configuration tests
       | KIE_SERVER_CONTROLLER_PWD  | customCtl!0 |
       | KIE_SERVER_USER            | customExe   |
       | KIE_SERVER_PWD             | customExe!0 |
-    Then file /opt/eap/standalone/configuration/application-users.properties should not contain customAdm
-     And file /opt/eap/standalone/configuration/application-roles.properties should not contain customAdm
+    Then file /opt/eap/standalone/configuration/application-users.properties should contain customAdm=05ad559f03f4a06845bf201990f6832f
+     And file /opt/eap/standalone/configuration/application-roles.properties should contain customAdm=kie-server,rest-all,admin,kiemgmt,Administrators
      And file /opt/eap/standalone/configuration/application-users.properties should not contain customMvn
      And file /opt/eap/standalone/configuration/application-roles.properties should not contain customMvn
      And file /opt/eap/standalone/configuration/application-users.properties should not contain customCtl


### PR DESCRIPTION
[RHPAM-891] maven users created in eap unnecessarily
https://issues.jboss.org/browse/RHPAM-891

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
