### PR TITLE
[RHPAM-1135] Unable to use spaces in passwords: remove wip tags in tests

### DIFF
--- a/tests/features/rhpam/kieserver/rhpam-kieserver.feature
+++ b/tests/features/rhpam/kieserver/rhpam-kieserver.feature
@@ -12,7 +12,6 @@ Feature: RHPAM KIE Server configuration tests
      And run sh -c 'echo $RHPAM_KIESERVER_VERSION' in container and check its output for 7.0.0
 
   # https://issues.jboss.org/browse/RHPAM-891
-  @wip
   Scenario: Check default users are properly configured
     When container is ready
     Then file /opt/eap/standalone/configuration/application-users.properties should contain adminUser=de3155e1927c6976555925dec24a53ac
@@ -26,7 +25,6 @@ Feature: RHPAM KIE Server configuration tests
 
   # https://issues.jboss.org/browse/RHPAM-891
   # https://issues.jboss.org/browse/RHPAM-1135
-  @wip
   Scenario: Check custom users are properly configured
     When container is started with env
       | variable                   | value         |


### PR DESCRIPTION
[RHPAM-1135] Unable to use spaces in passwords: remove wip tags in tests
https://issues.jboss.org/browse/RHPAM-1135

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

[RHPAM-1135] Unable to use spaces in passwords: remove wip tags in testsPlease make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
