### PR TITLE
[RHPAM-1135] Cannot use spaces in passwords - followup to use exec array

### DIFF
--- a/os.bpmsuite.businesscentral/added/openshift-launch.sh
+++ b/os.bpmsuite.businesscentral/added/openshift-launch.sh
@@ -44,5 +44,18 @@ if [ -n "$CLI_GRACEFUL_SHUTDOWN" ] ; then
   log_info "Using CLI Graceful Shutdown instead of TERM signal"
 fi
 
-# eval instead of exec to handle spaces in system properties (like passwords per RHPAM-1135)
-eval env M2_HOME=${M2_HOME} $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 ${JAVA_PROXY_OPTIONS} ${JBOSS_HA_ARGS} ${JBOSS_MESSAGING_ARGS} ${JBOSS_BPMSUITE_ARGS}
+# RHPAM-1135: We need to build and pass an array otherwise spaces in passwords will break the exec
+D_OPTS="${JBOSS_BPMSUITE_ARGS}"
+D_DLM=" -D"
+D_STR=" ${D_OPTS}${D_DLM}"
+D_ARR=()
+while [[ $D_STR ]]; do
+    D_TMP="${D_STR%%"$D_DLM"*}"
+    if [[ ! "${D_TMP}" =~ ^\ +$ ]] && [[ "x${D_TMP}" != "x" ]]; then
+        D_TMP=$(eval "echo \"${D_TMP}\"")
+        D_ARR+=("-D${D_TMP}")
+    fi
+    D_STR=${D_STR#*"$D_DLM"}
+done
+
+exec env M2_HOME=${M2_HOME} $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 ${JAVA_PROXY_OPTIONS} ${JBOSS_HA_ARGS} ${JBOSS_MESSAGING_ARGS} "${D_ARR[@]}"

--- a/os.bpmsuite.elasticsearch/added/openshift-launch.sh
+++ b/os.bpmsuite.elasticsearch/added/openshift-launch.sh
@@ -16,5 +16,4 @@ source $ELASTICSEARCH_HOME/bin/launch/configure.sh
 
 echo "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION"
 
-# eval instead of exec to handle spaces in system properties (like passwords per RHPAM-1135)
-eval $ELASTICSEARCH_HOME/bin/elasticsearch ${ELASTICSEARCH_ARGS}
+exec $ELASTICSEARCH_HOME/bin/elasticsearch ${ELASTICSEARCH_ARGS}

--- a/os.bpmsuite.executionserver/added/openshift-launch.sh
+++ b/os.bpmsuite.executionserver/added/openshift-launch.sh
@@ -44,5 +44,18 @@ if [ -n "$CLI_GRACEFUL_SHUTDOWN" ] ; then
   log_info "Using CLI Graceful Shutdown instead of TERM signal"
 fi
 
-# eval instead of exec to handle spaces in system properties (like passwords per RHPAM-1135)
-eval env M2_HOME=${M2_HOME} $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 ${JAVA_PROXY_OPTIONS} ${JBOSS_HA_ARGS} ${JBOSS_MESSAGING_ARGS} ${JBOSS_BPMSUITE_ARGS}
+# RHPAM-1135: We need to build and pass an array otherwise spaces in passwords will break the exec
+D_OPTS="${JBOSS_BPMSUITE_ARGS}"
+D_DLM=" -D"
+D_STR=" ${D_OPTS}${D_DLM}"
+D_ARR=()
+while [[ $D_STR ]]; do
+    D_TMP="${D_STR%%"$D_DLM"*}"
+    if [[ ! "${D_TMP}" =~ ^\ +$ ]] && [[ "x${D_TMP}" != "x" ]]; then
+        D_TMP=$(eval "echo \"${D_TMP}\"")
+        D_ARR+=("-D${D_TMP}")
+    fi
+    D_STR=${D_STR#*"$D_DLM"}
+done
+
+exec env M2_HOME=${M2_HOME} $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 ${JAVA_PROXY_OPTIONS} ${JBOSS_HA_ARGS} ${JBOSS_MESSAGING_ARGS} "${D_ARR[@]}"

--- a/os.bpmsuite.standalonecontroller/added/openshift-launch.sh
+++ b/os.bpmsuite.standalonecontroller/added/openshift-launch.sh
@@ -43,5 +43,18 @@ if [ -n "$CLI_GRACEFUL_SHUTDOWN" ] ; then
   log_info "Using CLI Graceful Shutdown instead of TERM signal"
 fi
 
-# eval instead of exec to handle spaces in system properties (like passwords per RHPAM-1135)
-eval env M2_HOME=${M2_HOME} $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 ${JAVA_PROXY_OPTIONS} ${JBOSS_HA_ARGS} ${JBOSS_MESSAGING_ARGS} ${JBOSS_BPMSUITE_ARGS}
+# RHPAM-1135: We need to build and pass an array otherwise spaces in passwords will break the exec
+D_OPTS="${JBOSS_BPMSUITE_ARGS}"
+D_DLM=" -D"
+D_STR=" ${D_OPTS}${D_DLM}"
+D_ARR=()
+while [[ $D_STR ]]; do
+    D_TMP="${D_STR%%"$D_DLM"*}"
+    if [[ ! "${D_TMP}" =~ ^\ +$ ]] && [[ "x${D_TMP}" != "x" ]]; then
+        D_TMP=$(eval "echo \"${D_TMP}\"")
+        D_ARR+=("-D${D_TMP}")
+    fi
+    D_STR=${D_STR#*"$D_DLM"}
+done
+
+exec env M2_HOME=${M2_HOME} $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 ${JAVA_PROXY_OPTIONS} ${JBOSS_HA_ARGS} ${JBOSS_MESSAGING_ARGS} "${D_ARR[@]}"


### PR DESCRIPTION
[RHPAM-1135] Cannot use spaces in passwords - followup to use exec array
https://issues.jboss.org/browse/RHPAM-1135

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
