### PR TITLE
[RHPAM-1210] Allow LDAP authentication

### DIFF
--- a/os.bpmsuite.common/added/launch/bpmsuite-common.sh
+++ b/os.bpmsuite.common/added/launch/bpmsuite-common.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 source /usr/local/s2i/scl-enable-maven
+source "${JBOSS_HOME}/bin/launch/bpmsuite-security-ldap.sh"
 
 function prepareEnv() {
     # please keep these in alphabetical order
     unset KIE_MBEANS
+    unset_kie_security_ldap_env
 }
 
 function configureEnv() {
@@ -14,6 +16,7 @@ function configureEnv() {
 function configure() {
     configure_maven_settings
     configure_mbeans
+    configure_ldap_security_domain
 }
 
 function configure_maven_settings() {

--- a/os.bpmsuite.common/added/launch/bpmsuite-security-ldap.sh
+++ b/os.bpmsuite.common/added/launch/bpmsuite-security-ldap.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+########## Environment Variables ##########
+
+function unset_kie_security_ldap_env() {
+    # please keep these in alphabetical order
+    unset KIE_AUTH_LDAP_ALLOW_EMPTY_PASSWORDS
+    unset KIE_AUTH_LDAP_BASE_CTX_DN
+    unset KIE_AUTH_LDAP_BASE_FILTER
+    unset KIE_AUTH_LDAP_BIND_CREDENTIAL
+    unset KIE_AUTH_LDAP_BIND_DN
+    unset KIE_AUTH_LDAP_DEFAULT_ROLE
+    unset KIE_AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
+    unset KIE_AUTH_LDAP_JAAS_SECURITY_DOMAIN
+    unset KIE_AUTH_LDAP_PARSE_ROLE_NAME_FROM_DN
+    unset KIE_AUTH_LDAP_PARSE_USERNAME
+    unset KIE_AUTH_LDAP_REFERRAL_USER_ATTRIBUTE_ID_TO_CHECK
+    unset KIE_AUTH_LDAP_ROLE_ATTRIBUTE_ID
+    unset KIE_AUTH_LDAP_ROLE_ATTRIBUTE_IS_DN
+    unset KIE_AUTH_LDAP_ROLE_FILTER
+    unset KIE_AUTH_LDAP_ROLE_NAME_ATTRIBUTE_ID
+    unset KIE_AUTH_LDAP_ROLE_RECURSION
+    unset KIE_AUTH_LDAP_ROLES_CTX_DN
+    unset KIE_AUTH_LDAP_SEARCH_SCOPE
+    unset KIE_AUTH_LDAP_SEARCH_TIME_LIMIT
+    unset KIE_AUTH_LDAP_URL
+    unset KIE_AUTH_LDAP_USERNAME_BEGIN_STRING
+    unset KIE_AUTH_LDAP_USERNAME_END_STRING
+}
+
+function add_module() {
+    local xml=$1
+    local name=$2
+    local envVar=$3
+
+    if [[ ! -z ${envVar} ]]; then
+        echo ${xml} '<module-option name="'${name}'" value="'${envVar}'"/>'
+    else
+        echo ${xml}
+    fi
+}
+
+function configure_ldap_security_domain() {
+    if [[ -z ${KIE_AUTH_LDAP_URL} ]]; then
+        log_info "KIE_AUTH_LDAP_URL not set. Skipping LDAP integration..."
+        return
+    fi
+    log_info "KIE_AUTH_LDAP_URL is set to ${KIE_AUTH_LDAP_URL}. Added LdapExtended login-module"
+    local security_domain='<login-module code="LdapExtended" flag="required">'
+
+    security_domain=$(add_module "$security_domain" "java.naming.provider.url" "${KIE_AUTH_LDAP_URL}") 
+    security_domain=$(add_module "$security_domain" "jaasSecurityDomain" "${KIE_AUTH_LDAP_JAAS_SECURITY_DOMAIN}") 
+    security_domain=$(add_module "$security_domain" "bindDN" "${KIE_AUTH_LDAP_BIND_DN}") 
+    security_domain=$(add_module "$security_domain" "bindCredential" "${KIE_AUTH_LDAP_BIND_CREDENTIAL}") 
+    security_domain=$(add_module "$security_domain" "baseCtxDN" "${KIE_AUTH_LDAP_BASE_CTX_DN}") 
+    security_domain=$(add_module "$security_domain" "baseFilter" "${KIE_AUTH_LDAP_BASE_FILTER}")
+    security_domain=$(add_module "$security_domain" "rolesCtxDN" "${KIE_AUTH_LDAP_ROLES_CTX_DN}") 
+    security_domain=$(add_module "$security_domain" "roleFilter" "${KIE_AUTH_LDAP_ROLE_FILTER}")
+    security_domain=$(add_module "$security_domain" "roleAttributeID" "${KIE_AUTH_LDAP_ROLE_ATTRIBUTE_ID}")
+    security_domain=$(add_module "$security_domain" "roleAttributeIsDN" "${KIE_AUTH_LDAP_ROLE_ATTRIBUTE_IS_DN}")
+    security_domain=$(add_module "$security_domain" "roleNameAttributeID" "${KIE_AUTH_LDAP_ROLE_NAME_ATTRIBUTE_ID}")
+    security_domain=$(add_module "$security_domain" "defaultRole" "${KIE_AUTH_LDAP_DEFAULT_ROLE}")
+    security_domain=$(add_module "$security_domain" "roleRecursion" "${KIE_AUTH_LDAP_ROLE_RECURSION}")
+    security_domain=$(add_module "$security_domain" "distinguishedNameAttribute" "${KIE_AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}")
+    security_domain=$(add_module "$security_domain" "parseRoleNameFromDN" "${KIE_AUTH_LDAP_PARSE_ROLE_NAME_FROM_DN}")
+    security_domain=$(add_module "$security_domain" "parseUsername" "${KIE_AUTH_LDAP_PARSE_USERNAME}")
+    security_domain=$(add_module "$security_domain" "usernameBeginString" "${KIE_AUTH_LDAP_USERNAME_BEGIN_STRING}")
+    security_domain=$(add_module "$security_domain" "usernameEndString" "${KIE_AUTH_LDAP_USERNAME_END_STRING}")
+    security_domain=$(add_module "$security_domain" "searchTimeLimit" "${KIE_AUTH_LDAP_SEARCH_TIME_LIMIT}")
+    security_domain=$(add_module "$security_domain" "searchScope" "${KIE_AUTH_LDAP_SEARCH_SCOPE}")
+    security_domain=$(add_module "$security_domain" "allowEmptyPasswords" "${KIE_AUTH_LDAP_ALLOW_EMPTY_PASSWORDS}")
+    security_domain=$(add_module "$security_domain" "referralUserAttributeIDToCheck" "${KIE_AUTH_LDAP_REFERRAL_USER_ATTRIBUTE_ID_TO_CHECK}") 
+    
+    security_domain="${security_domain}"'</login-module><!-- ##OTHER_LOGIN_MODULES## -->'
+
+    sed -i "s|<!-- ##OTHER_LOGIN_MODULES## -->|${security_domain}|" "${CONFIG_FILE}"
+}

--- a/os.bpmsuite.common/tests/bats/bpmsuite-common.bash
+++ b/os.bpmsuite.common/tests/bats/bpmsuite-common.bash
@@ -1,0 +1,9 @@
+load ../../../tests/bats/common/logging
+
+function assert_xml() {
+  local file=$1
+  local expected=$2
+  local xml=$(xmllint $file)
+
+  diff -Ew <(echo $xml | xmllint --format -) $expected
+}

--- a/os.bpmsuite.common/tests/bats/bpmsuite-security-ldap.bats
+++ b/os.bpmsuite.common/tests/bats/bpmsuite-security-ldap.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load bpmsuite-common
+
+export JBOSS_HOME=$BATS_TMPDIR/jboss_home
+mkdir -p $JBOSS_HOME/standalone/configuration
+mkdir -p $JBOSS_HOME/bin/launch
+
+export CONFIG_FILE=$JBOSS_HOME/standalone/configuration/standalone-openshift.xml
+
+source $BATS_TEST_DIRNAME/../../added/launch/bpmsuite-security-ldap.sh
+
+setup() {
+  cp $BATS_TEST_DIRNAME/resources/standalone-openshift.xml $CONFIG_FILE
+  run unset_kie_security_ldap_env
+}
+
+@test "do not replace placeholder when URL is not provided" {
+    KIE_AUTH_LDAP_ALLOW_EMPTY_PWD="test KIE_AUTH_LDAP_ALLOW_EMPTY_PWD"
+    KIE_AUTH_LDAP_BASE_DN="test KIE_AUTH_LDAP_BASE_DN"
+    KIE_AUTH_LDAP_BASE_FILTER="test KIE_AUTH_LDAP_BASE_FILTER"
+    KIE_AUTH_LDAP_BIND_DN="test KIE_AUTH_LDAP_BIND_DN"
+    KIE_AUTH_LDAP_BIND_PWD="test KIE_AUTH_LDAP_BIND_PWD"
+    KIE_AUTH_LDAP_ROLE_ATTR_ID="test KIE_AUTH_LDAP_ROLE_ATTR_ID"
+    KIE_AUTH_LDAP_ROLE_ATTR_IS_DN="test KIE_AUTH_LDAP_ROLE_ATTR_IS_DN"
+    KIE_AUTH_LDAP_ROLE_DN="test KIE_AUTH_LDAP_ROLE_DN"
+    KIE_AUTH_LDAP_ROLE_FILTER="test KIE_AUTH_LDAP_ROLE_FILTER"
+    KIE_AUTH_LDAP_ROLE_NAME_ATTR_ID="test KIE_AUTH_LDAP_ROLE_NAME_ATTR_ID"
+    KIE_AUTH_LDAP_SEARCH_SCOPE="test KIE_AUTH_LDAP_SEARCH_SCOPE"
+
+    run configure_ldap_security_domain
+
+    [ "$output" = "[INFO]KIE_AUTH_LDAP_URL not set. Skipping LDAP integration..." ]
+    [ "$status" -eq 0 ]
+    assert_xml $CONFIG_FILE $BATS_TEST_DIRNAME/expectations/standalone-openshift-untouched.xml
+}
+
+@test "replace placeholder by minimum xml content when URL is provided" {
+    KIE_AUTH_LDAP_URL="test_url"
+
+    run configure_ldap_security_domain
+
+    [ "$output" = "[INFO]KIE_AUTH_LDAP_URL is set to test_url. Added LdapExtended login-module" ]
+    [ "$status" -eq 0 ]
+    assert_xml $CONFIG_FILE $BATS_TEST_DIRNAME/expectations/standalone-openshift-ldap-url.xml
+}
+
+@test "replace placeholder by all LDAP values when provided" {
+    KIE_AUTH_LDAP_ALLOW_EMPTY_PASSWORDS="test KIE_AUTH_LDAP_ALLOW_EMPTY_PASSWORDS"
+    KIE_AUTH_LDAP_BASE_CTX_DN="test KIE_AUTH_LDAP_BASE_CTX_DN"
+    KIE_AUTH_LDAP_BASE_FILTER="test KIE_AUTH_LDAP_BASE_FILTER"
+    KIE_AUTH_LDAP_BIND_CREDENTIAL="test KIE_AUTH_LDAP_BIND_CREDENTIAL"
+    KIE_AUTH_LDAP_BIND_DN="test KIE_AUTH_LDAP_BIND_DN"
+    KIE_AUTH_LDAP_DEFAULT_ROLE="test KIE_AUTH_LDAP_DEFAULT_ROLE"
+    KIE_AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE="test KIE_AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE"
+    KIE_AUTH_LDAP_JAAS_SECURITY_DOMAIN="test KIE_AUTH_LDAP_JAAS_SECURITY_DOMAIN"
+    KIE_AUTH_LDAP_PARSE_ROLE_NAME_FROM_DN="test KIE_AUTH_LDAP_PARSE_ROLE_NAME_FROM_DN"
+    KIE_AUTH_LDAP_PARSE_USERNAME="test KIE_AUTH_LDAP_PARSE_USERNAME"
+    KIE_AUTH_LDAP_REFERRAL_USER_ATTRIBUTE_ID_TO_CHECK="test KIE_AUTH_LDAP_REFERRAL_USER_ATTRIBUTE_ID_TO_CHECK"
+    KIE_AUTH_LDAP_ROLE_ATTRIBUTE_ID="test KIE_AUTH_LDAP_ROLE_ATTRIBUTE_ID"
+    KIE_AUTH_LDAP_ROLE_ATTRIBUTE_IS_DN="test KIE_AUTH_LDAP_ROLE_ATTRIBUTE_IS_DN"
+    KIE_AUTH_LDAP_ROLE_FILTER="test KIE_AUTH_LDAP_ROLE_FILTER"
+    KIE_AUTH_LDAP_ROLE_NAME_ATTRIBUTE_ID="test KIE_AUTH_LDAP_ROLE_NAME_ATTRIBUTE_ID"
+    KIE_AUTH_LDAP_ROLE_RECURSION="test KIE_AUTH_LDAP_ROLE_RECURSION"
+    KIE_AUTH_LDAP_ROLES_CTX_DN="test KIE_AUTH_LDAP_ROLES_CTX_DN"
+    KIE_AUTH_LDAP_SEARCH_SCOPE="test KIE_AUTH_LDAP_SEARCH_SCOPE"
+    KIE_AUTH_LDAP_SEARCH_TIME_LIMIT="test KIE_AUTH_LDAP_SEARCH_TIME_LIMIT"
+    KIE_AUTH_LDAP_URL="test KIE_AUTH_LDAP_URL"
+    KIE_AUTH_LDAP_USERNAME_BEGIN_STRING="test KIE_AUTH_LDAP_USERNAME_BEGIN_STRING"
+    KIE_AUTH_LDAP_USERNAME_END_STRING="test KIE_AUTH_LDAP_USERNAME_END_STRING"
+
+    run configure_ldap_security_domain
+
+    [ "$output" = "[INFO]KIE_AUTH_LDAP_URL is set to test KIE_AUTH_LDAP_URL. Added LdapExtended login-module" ]
+    [ "$status" -eq 0 ]
+    assert_xml $CONFIG_FILE $BATS_TEST_DIRNAME/expectations/standalone-openshift-ldap-all.xml
+}

--- a/os.bpmsuite.common/tests/bats/expectations/standalone-openshift-ldap-all.xml
+++ b/os.bpmsuite.common/tests/bats/expectations/standalone-openshift-ldap-all.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<subsystem xmlns="urn:jboss:domain:security:2.0">
+    <!-- ##ELYTRON_INTEGRATION## -->
+    <security-domains>
+        <security-domain name="other" cache-type="default">
+            <authentication>
+                <login-module code="Remoting" flag="optional">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="RealmDirect" flag="required">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="LdapExtended" flag="required">
+                    <module-option name="java.naming.provider.url" value="test KIE_AUTH_LDAP_URL"/>
+                    <module-option name="jaasSecurityDomain" value="test KIE_AUTH_LDAP_JAAS_SECURITY_DOMAIN"/>
+                    <module-option name="bindDN" value="test KIE_AUTH_LDAP_BIND_DN"/>
+                    <module-option name="bindCredential" value="test KIE_AUTH_LDAP_BIND_CREDENTIAL"/>
+                    <module-option name="baseCtxDN" value="test KIE_AUTH_LDAP_BASE_CTX_DN"/>
+                    <module-option name="baseFilter" value="test KIE_AUTH_LDAP_BASE_FILTER"/>
+                    <module-option name="rolesCtxDN" value="test KIE_AUTH_LDAP_ROLES_CTX_DN"/>
+                    <module-option name="roleFilter" value="test KIE_AUTH_LDAP_ROLE_FILTER"/>
+                    <module-option name="roleAttributeID" value="test KIE_AUTH_LDAP_ROLE_ATTRIBUTE_ID"/>
+                    <module-option name="roleAttributeIsDN" value="test KIE_AUTH_LDAP_ROLE_ATTRIBUTE_IS_DN"/>
+                    <module-option name="roleNameAttributeID" value="test KIE_AUTH_LDAP_ROLE_NAME_ATTRIBUTE_ID"/>
+                    <module-option name="defaultRole" value="test KIE_AUTH_LDAP_DEFAULT_ROLE"/>
+                    <module-option name="roleRecursion" value="test KIE_AUTH_LDAP_ROLE_RECURSION"/>
+                    <module-option name="distinguishedNameAttribute" value="test KIE_AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE"/>
+                    <module-option name="parseRoleNameFromDN" value="test KIE_AUTH_LDAP_PARSE_ROLE_NAME_FROM_DN"/>
+                    <module-option name="parseUsername" value="test KIE_AUTH_LDAP_PARSE_USERNAME"/>
+                    <module-option name="usernameBeginString" value="test KIE_AUTH_LDAP_USERNAME_BEGIN_STRING"/>
+                    <module-option name="usernameEndString" value="test KIE_AUTH_LDAP_USERNAME_END_STRING"/>
+                    <module-option name="searchTimeLimit" value="test KIE_AUTH_LDAP_SEARCH_TIME_LIMIT"/>
+                    <module-option name="searchScope" value="test KIE_AUTH_LDAP_SEARCH_SCOPE"/>
+                    <module-option name="allowEmptyPasswords" value="test KIE_AUTH_LDAP_ALLOW_EMPTY_PASSWORDS"/>
+                    <module-option name="referralUserAttributeIDToCheck" value="test KIE_AUTH_LDAP_REFERRAL_USER_ATTRIBUTE_ID_TO_CHECK"/>
+                </login-module>
+                <!-- ##OTHER_LOGIN_MODULES## -->
+            </authentication>
+        </security-domain>
+        <security-domain name="jboss-web-policy" cache-type="default">
+            <authorization>
+                <policy-module code="Delegating" flag="required"/>
+            </authorization>
+        </security-domain>
+        <security-domain name="jboss-ejb-policy" cache-type="default">
+            <authorization>
+                <policy-module code="Delegating" flag="required"/>
+            </authorization>
+        </security-domain>
+        <!-- ##KEYCLOAK_SECURITY_DOMAIN## -->
+        <!-- ##ADDITIONAL_SECURITY_DOMAINS## -->
+    </security-domains>
+</subsystem>

--- a/os.bpmsuite.common/tests/bats/expectations/standalone-openshift-ldap-url.xml
+++ b/os.bpmsuite.common/tests/bats/expectations/standalone-openshift-ldap-url.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<subsystem xmlns="urn:jboss:domain:security:2.0">
+    <!-- ##ELYTRON_INTEGRATION## -->
+    <security-domains>
+        <security-domain name="other" cache-type="default">
+            <authentication>
+                <login-module code="Remoting" flag="optional">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="RealmDirect" flag="required">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="LdapExtended" flag="required">
+                    <module-option name="java.naming.provider.url" value="test_url"/>
+                </login-module>
+                <!-- ##OTHER_LOGIN_MODULES## -->
+            </authentication>
+        </security-domain>
+        <security-domain name="jboss-web-policy" cache-type="default">
+            <authorization>
+                <policy-module code="Delegating" flag="required"/>
+            </authorization>
+        </security-domain>
+        <security-domain name="jboss-ejb-policy" cache-type="default">
+            <authorization>
+                <policy-module code="Delegating" flag="required"/>
+            </authorization>
+        </security-domain>
+        <!-- ##KEYCLOAK_SECURITY_DOMAIN## -->
+        <!-- ##ADDITIONAL_SECURITY_DOMAINS## -->
+        </security-domains>
+</subsystem>

--- a/os.bpmsuite.common/tests/bats/expectations/standalone-openshift-untouched.xml
+++ b/os.bpmsuite.common/tests/bats/expectations/standalone-openshift-untouched.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<subsystem xmlns="urn:jboss:domain:security:2.0">
+    <!-- ##ELYTRON_INTEGRATION## -->
+    <security-domains>
+        <security-domain name="other" cache-type="default">
+            <authentication>
+                <login-module code="Remoting" flag="optional">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="RealmDirect" flag="required">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <!-- ##OTHER_LOGIN_MODULES## -->
+            </authentication>
+        </security-domain>
+        <security-domain name="jboss-web-policy" cache-type="default">
+            <authorization>
+                <policy-module code="Delegating" flag="required"/>
+            </authorization>
+        </security-domain>
+        <security-domain name="jboss-ejb-policy" cache-type="default">
+            <authorization>
+                <policy-module code="Delegating" flag="required"/>
+            </authorization>
+        </security-domain>
+        <!-- ##KEYCLOAK_SECURITY_DOMAIN## -->
+        <!-- ##ADDITIONAL_SECURITY_DOMAINS## -->
+        </security-domains>
+</subsystem>

--- a/os.bpmsuite.common/tests/bats/resources/standalone-openshift.xml
+++ b/os.bpmsuite.common/tests/bats/resources/standalone-openshift.xml
@@ -1,0 +1,28 @@
+        <subsystem xmlns="urn:jboss:domain:security:2.0">
+            <!-- ##ELYTRON_INTEGRATION## -->
+            <security-domains>
+                <security-domain name="other" cache-type="default">
+                    <authentication>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <!-- ##OTHER_LOGIN_MODULES## -->
+                    </authentication>
+                </security-domain>
+                <security-domain name="jboss-web-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jboss-ejb-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <!-- ##KEYCLOAK_SECURITY_DOMAIN## -->
+                <!-- ##ADDITIONAL_SECURITY_DOMAINS## -->
+             </security-domains>
+        </subsystem>

--- a/tests/bats/common/logging.bash
+++ b/tests/bats/common/logging.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function log_info() {
+    echo "[INFO]"$1
+}
+
+function log_error() {
+    echo "[ERROR]"$1
+}
+
+function log_warn() {
+    echo "[WARN]"$1
+}

--- a/tests/features/common/kieserver/kieserver-common.feature
+++ b/tests/features/common/kieserver/kieserver-common.feature
@@ -30,3 +30,15 @@ Feature: Kie Server common features
       | KIE_SERVER_STARTUP_STRATEGY | invalid  |
     Then container log should contain -Dorg.kie.server.mgmt.api.disabled=true
     And container log should contain The startup strategy invalid is not valid, the valid strategies are LocalContainersStartupStrategy and ControllerBasedStartupStrategy
+  
+  Scenario: Don't configure kie server to use LDAP authentication
+    When container is ready
+    Then container log should contain KIE_AUTH_LDAP_URL not set. Skipping LDAP integration...
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should not contain <login-module code="LdapExtended"
+
+  Scenario: Configure kie server to use LDAP authentication
+    When container is started with env
+      | variable          | value     |
+      | KIE_AUTH_LDAP_URL | test_url  |
+    Then container log should contain KIE_AUTH_LDAP_URL is set to test_url. Added LdapExtended login-module
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <login-module code="LdapExtended"


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Thanks for submitting your Pull Request!

Fixes https://issues.jboss.org/browse/RHPAM-1210

Added all possible parameters allowed by [LdapExtended LoginModule](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html-single/login_module_reference/#ldapextended_login_module)
