### PR TITLE
[RHPAM-1179] Align EJB Timer configurations

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -75,109 +75,86 @@ function configure_EJB_Timer_datasource {
             log_info "configuring EJB Timer Datasource based on DB_SERVICE_PREFIX_MAPPING env"
             local serviceMappingName=${DB_SERVICE_PREFIX_MAPPING%=*}
             local prefix=${DB_SERVICE_PREFIX_MAPPING#*=}
+            local service=${serviceMappingName^^}
+            service=${service//-/_}
 
-            EJB_TIMER_JNDI=$(find_env "${prefix}_JNDI")
-            EJB_TIMER_JNDI="${EJB_TIMER_JNDI}_EJBTimer"
+            DB_SERVICE_PREFIX_MAPPING="${serviceMappingName}=EJB_TIMER,${DB_SERVICE_PREFIX_MAPPING}"
+            TIMER_SERVICE_DATA_STORE="${serviceMappingName}"
+            EJB_TIMER_DRIVER=${serviceMappingName##*-}
 
-            # force the provided datasource to be xa
-            eval ${prefix}_NONXA=false
-
-            #mysql need to be created manually because the DB_SERVICE_PREFIX_MAPPING does not allow to configure the XA URL
-            if [[ "${serviceMappingName}" = *"mysql"* ]]; then
-                DATASOURCES="EJB_TIMER"
-
-                local service=${serviceMappingName^^}
-                service=${service//-/_}
-                local host=$(find_env "${service}_SERVICE_HOST")
-                local port=$(find_env "${service}_SERVICE_PORT" "3306")
-                local database=$(find_env "${prefix}_DATABASE")
-                EJB_TIMER_DRIVER="mysql"
-                EJB_TIMER_XA_CONNECTION_PROPERTY_URL="jdbc:mysql://${host}:${port}/${database}?pinGlobalTxToPhysicalConnection=true"
-                EJB_TIMER_CONNECTION_CHECKER=$(find_env "${prefix}_CONNECTION_CHECKER" "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker")
-                EJB_TIMER_EXCEPTION_SORTER=$(find_env "${prefix}_EXCEPTION_SORTER" "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter")
-                EJB_TIMER_BACKGROUND_VALIDATION=$(find_env "${prefix}_BACKGROUND_VALIDATION" "true")
-                EJB_TIMER_BACKGROUND_VALIDATION_MILLIS=$(find_env "${prefix}_BACKGROUND_VALIDATION_MILLIS" "10000")
-                TIMER_SERVICE_DATA_STORE="EJB_TIMER"
-            else
-                # Make sure that the EJB datasource is configured first, in this way the timer's default-data-store wil be the
-                # EJBTimer datasource
-                DB_SERVICE_PREFIX_MAPPING="${serviceMappingName}=EJB_TIMER,${DB_SERVICE_PREFIX_MAPPING}"
-                EJB_TIMER_DATABASE=$(find_env "${prefix}_DATABASE")
-                EJB_TIMER_DRIVER="postgresql"
-                TIMER_SERVICE_DATA_STORE="${serviceMappingName}"
-            fi
-            EJB_TIMER_USERNAME=$(find_env "${prefix}_USERNAME")
-            EJB_TIMER_PASSWORD=$(find_env "${prefix}_PASSWORD")
-            EJB_TIMER_MIN_POOL_SIZE=$(find_env "${prefix}_MIN_POOL_SIZE")
-            EJB_TIMER_MAX_POOL_SIZE=$(find_env "${prefix}_MAX_POOL_SIZE")
-            EJB_TIMER_TX_ISOLATION="${EJB_TIMER_TX_ISOLATION:-TRANSACTION_READ_COMMITTED}"
-            EJB_TIMER_NONXA="false"
-            #inject_ejb_timer_datastore
-
+            set_timer_env $prefix $service
         elif [ -n "${DATASOURCES}" ]; then
             log_info "configuring EJB Timer Datasource based on DATASOURCES env"
             # Make sure that the EJB datasource is configured first, in this way the timer's default-data-store wil be the
             # EJBTimer datasource
             local dsPrefix="${DATASOURCES%,*}"
-            # force the provided datasource to be xa
-            eval ${dsPrefix}_NONXA=false
-
             DATASOURCES="EJB_TIMER,${DATASOURCES}"
-
-            EJB_TIMER_DRIVER=$(find_env "${dsPrefix}_DRIVER")
-
-            if [ "${EJB_TIMER_DRIVER}" = "postgresql" ]; then
-                EJB_TIMER_DATABASE=$(find_env "${dsPrefix}_DATABASE")
-                EJB_TIMER_SERVICE_HOST=$(find_env "${dsPrefix}_SERVICE_HOST")
-                EJB_TIMER_SERVICE_PORT=$(find_env "${dsPrefix}_SERVICE_PORT")
-
-            elif [ "${EJB_TIMER_DRIVER}" = "mysql" ]; then
-                local host=$(find_env "${dsPrefix}_SERVICE_HOST")
-                local port=$(find_env "${dsPrefix}_SERVICE_PORT" "3306")
-                local database=$(find_env "${dsPrefix}_DATABASE")
-                EJB_TIMER_XA_CONNECTION_PROPERTY_URL="jdbc:mysql://${host}:${port}/${database}?pinGlobalTxToPhysicalConnection=true"
-            else
-                # these values are set automatically it the driver is mysql or postgresql, if the driver does not match, these values must be provided
-                EJB_TIMER_CONNECTION_CHECKER=$(find_env "${dsPrefix}_CONNECTION_CHECKER")
-                EJB_TIMER_EXCEPTION_SORTER=$(find_env "${dsPrefix}_EXCEPTION_SORTER")
-                EJB_TIMER_BACKGROUND_VALIDATION=$(find_env "${dsPrefix}_BACKGROUND_VALIDATION")
-                EJB_TIMER_BACKGROUND_VALIDATION_MILLIS=$(find_env "${dsPrefix}_BACKGROUND_VALIDATION_MILLIS")
-
-                # if prefix_URL and prefix_XA_CONNECTION_PROPERTY_propertyName are set, rely on XA property
-                # the same will be valid for others XA properties
-                local url=$(find_env "${dsPrefix}_URL")
-                url=$(find_env "${dsPrefix}_XA_CONNECTION_PROPERTY_URL" "${url}")
-                if [ "x${url}" != "x" ]; then
-                    EJB_TIMER_XA_CONNECTION_PROPERTY_URL=${url}
-
-                else
-                    local databaseName=$(find_env "${dsPrefix}_DATABASE")
-                    databaseName=$(find_env "${dsPrefix}_XA_CONNECTION_PROPERTY_DatabaseName" "${databaseName}")
-                    local serverName=$(find_env "${dsPrefix}_SERVICE_HOST" )
-                    serverName=$(find_env "${dsPrefix}_XA_CONNECTION_PROPERTY_ServerName" "${serverName}")
-                    local portNumber=$(find_env "${dsPrefix}_SERVICE_PORT" )
-                    portNumber=$(find_env "${dsPrefix}_XA_CONNECTION_PROPERTY_PortNumber" "${portNumber}")
-                    EJB_TIMER_XA_CONNECTION_PROPERTY_DatabaseName=${databaseName}
-                    EJB_TIMER_XA_CONNECTION_PROPERTY_ServerName=${serverName}
-                    EJB_TIMER_XA_CONNECTION_PROPERTY_PortNumber=${portNumber}
-
-                    if [ "${EJB_TIMER_DRIVER}" = "db2" ]; then
-                        # default to 4, but user could define 2
-                        local driverType=$(find_env "${dsPrefix}_DRIVER_TYPE" "4")
-                        driverType=$(find_env "${dsPrefix}_XA_CONNECTION_PROPERTY_DriverType" "${driverType}")
-                        EJB_TIMER_XA_CONNECTION_PROPERTY_DriverType=${driverType}
-                    fi
-                fi
-            fi
-            EJB_TIMER_USERNAME=$(find_env "${dsPrefix}_USERNAME")
-            EJB_TIMER_PASSWORD=$(find_env "${dsPrefix}_PASSWORD")
-            EJB_TIMER_MIN_POOL_SIZE=$(find_env "${dsPrefix}_MIN_POOL_SIZE" "10")
-            EJB_TIMER_MAX_POOL_SIZE=$(find_env "${dsPrefix}_MAX_POOL_SIZE" "10")
-            EJB_TIMER_NONXA="false"
-            EJB_TIMER_TX_ISOLATION="${EJB_TIMER_TX_ISOLATION:-TRANSACTION_READ_COMMITTED}"
-            TIMER_SERVICE_DATA_STORE="EJB_TIMER"
+            set_timer_env $dsPrefix
         fi
     fi
+}
+
+function set_timer_env {
+    local prefix=$1
+    local service=$2
+
+    declare_timer_common_variables $prefix
+    set_timer_defaults
+    declare_xa_variables $prefix $service
+}
+
+function declare_timer_common_variables {
+    local common_vars=(DRIVER JNDI USERNAME PASSWORD TX_ISOLATION \
+                            XA_CONNECTION_PROPERTY_URL MAX_POOL_SIZE \
+                            MIN_POOL_SIZE CONNECTION_CHECKER EXCEPTION_SORTER \
+                            BACKGROUND_VALIDATION BACKGROUND_VALIDATION_MILLIS)
+
+    for var in ${common_vars[@]}; do
+        local value=$(find_env "${prefix}_${var}")
+        if [[ -n ${value} ]]; then
+            eval "EJB_TIMER_${var}"=${value}
+        fi
+    done
+}
+
+function set_timer_defaults {
+    EJB_TIMER_JNDI="${EJB_TIMER_JNDI}_EJBTimer"
+    EJB_TIMER_MAX_POOL_SIZE=${EJB_TIMER_MAX_POOL_SIZE:-"10"}
+    EJB_TIMER_MIN_POOL_SIZE=${EJB_TIMER_MIN_POOL_SIZE:-"10"}
+    EJB_TIMER_TX_ISOLATION="${EJB_TIMER_TX_ISOLATION:-TRANSACTION_READ_COMMITTED}"
+    if [[ $EJB_TIMER_DRIVER = "mysql" ]]; then
+        EJB_TIMER_XA_CONNECTION_PROPERTY_PinGlobalTxToPhysicalConnection="true"
+        EJB_TIMER_BACKGROUND_VALIDATION_MILLIS=${EJB_TIMER_BACKGROUND_VALIDATION_MILLIS:-"10000"}
+    fi
+}
+
+function get_svc_var {
+    local var=$1
+    local prop=$2
+    local prefix=$3
+    local svc=$4
+
+    local var_name=${prefix}_XA_CONNECTION_PROPERTY_${prop}
+    local value=$(find_env ${var_name})
+    if [[ -z ${value} ]]; then
+        value=$(find_env "${prefix}_SERVICE_${var}")
+        if [[ -n ${svc} && -z ${value} ]]; then
+            value=$(find_env "${svc}_SERVICE_${var}")
+        fi
+    fi
+    if [[ -n ${value} ]]; then
+        eval "EJB_TIMER_XA_CONNECTION_PROPERTY_${prop}"=${value}
+    fi
+}
+
+function declare_xa_variables {
+    local prefix=$1
+    local service=$2
+    database=$(find_env "${prefix}_DATABASE")
+    xa_database=$(find_env "${prefix}_XA_CONNECTION_PROPERTY_DatabaseName")
+    EJB_TIMER_XA_CONNECTION_PROPERTY_DatabaseName=${xa_database:-${database}}
+    get_svc_var "HOST" "ServerName" $prefix $service
+    get_svc_var "PORT" "PortNumber" $prefix $service
 }
 
 function configure_server_env {

--- a/tests/features/rhpam/kieserver/rhpam-kieserver.feature
+++ b/tests/features/rhpam/kieserver/rhpam-kieserver.feature
@@ -110,7 +110,10 @@ Feature: RHPAM KIE Server configuration tests
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ejb_timer-EJB_TIMER on XPath //*[local-name()='xa-datasource']/@pool-name
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='xa-datasource']/@use-java-context
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='xa-datasource']/@enabled
-     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:mysql://10.1.1.1:3306/bpms?pinGlobalTxToPhysicalConnection=true on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="URL"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value bpms on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PinGlobalTxToPhysicalConnection"]
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value bpmUser on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value bpmPass on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value TRANSACTION_READ_COMMITTED on XPath //*[local-name()='xa-datasource']/*[local-name()='transaction-isolation']
@@ -119,6 +122,9 @@ Feature: RHPAM KIE Server configuration tests
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/ExampleDS_EJBTimer on XPath //*[local-name()='database-data-store']/@datasource-jndi-name
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql on XPath //*[local-name()='database-data-store']/@database
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ejb_timer-EJB_TIMER_part on XPath //*[local-name()='database-data-store']/@partition
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10 on XPath //*[local-name()='xa-pool']/@min-pool-size
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10 on XPath //*[local-name()='xa-pool']/@max-pool-size
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10000 on XPath //*[local-name()='validation']/@background-validation-millis
 
   Scenario: Checks if the EJB Timer was successfully configured with PostgreSQL with DB_SERVICE_PREFIX_MAPPING env
     When container is started with env
@@ -205,7 +211,43 @@ Feature: RHPAM KIE Server configuration tests
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/ejb_timer on XPath //*[local-name()='xa-datasource']/@jndi-name
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='xa-datasource']/@use-java-context
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='xa-datasource']/@enabled
-     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:mysql://10.1.1.1:3306/bpms?pinGlobalTxToPhysicalConnection=true on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="URL"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value bpms on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PinGlobalTxToPhysicalConnection"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value bpmUser on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value bpmPass on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value TRANSACTION_READ_COMMITTED on XPath //*[local-name()='xa-datasource']/*[local-name()='transaction-isolation']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ejb_timer-EJB_TIMER_ds on XPath //*[local-name()='timer-service']/@default-data-store
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ejb_timer-EJB_TIMER_ds on XPath //*[local-name()='database-data-store']/@name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/ejb_timer on XPath //*[local-name()='database-data-store']/@datasource-jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql on XPath //*[local-name()='database-data-store']/@database
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ejb_timer-EJB_TIMER_part on XPath //*[local-name()='database-data-store']/@partition
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10000 on XPath //*[local-name()='database-data-store']/@refresh-interval
+
+  Scenario: Checks if the EJB Timer was successfully configured with MySQL with DATASOURCES env with URL
+    When container is started with env
+      | variable                                  | value                           |
+      | DATASOURCES                               | TEST                            |
+      | TEST_DATABASE                             | bpms                            |
+      | TEST_USERNAME                             | bpmUser                         |
+      | TEST_PASSWORD                             | bpmPass                         |
+      | TEST_DRIVER                               | mysql                           |
+      | TEST_XA_CONNECTION_PROPERTY_URL           | jdbc:mysql://10.1.1.1:3306/bpms |
+      | TEST_SERVICE_PORT                         | 3306                            |
+      | TEST_NONXA                                | true                            |
+      | TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL | 10000                           |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test on XPath //*[local-name()='xa-datasource']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='datasource']/@enabled
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='datasource']/@use-java-context
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql on XPath //*[local-name()='xa-datasource']/*[local-name()='driver']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ejb_timer-EJB_TIMER on XPath //*[local-name()='xa-datasource']/@pool-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/ejb_timer on XPath //*[local-name()='xa-datasource']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='xa-datasource']/@use-java-context
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='xa-datasource']/@enabled
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:mysql://10.1.1.1:3306/bpms on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="URL"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PinGlobalTxToPhysicalConnection"]
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value bpmUser on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value bpmPass on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value TRANSACTION_READ_COMMITTED on XPath //*[local-name()='xa-datasource']/*[local-name()='transaction-isolation']
@@ -285,24 +327,6 @@ Feature: RHPAM KIE Server configuration tests
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker on XPath //*[local-name()='xa-datasource']/*[local-name()='validation']/*[local-name()='valid-connection-checker']/@class-name
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter on XPath //*[local-name()='xa-datasource']/*[local-name()='validation']/*[local-name()='exception-sorter']/@class-name
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10000 on XPath //*[local-name()='database-data-store']/@refresh-interval
-
-  Scenario: Checks if the EJB Timer was successfully configured for an external DB2 datasource with Type 4 (default type) and env using XA connection properties
-    When container is started with env
-      | variable                                  | value                           |
-      | DATASOURCES                               | TEST                            |
-      | TEST_USERNAME                             | bpmUser                         |
-      | TEST_PASSWORD                             | bpmPass                         |
-      | TEST_DRIVER                               | db2                             |
-      | TEST_XA_CONNECTION_PROPERTY_ServerName    | 127.0.0.1                       |
-      | TEST_XA_CONNECTION_PROPERTY_DatabaseName  | bpms                            |
-      | TEST_XA_CONNECTION_PROPERTY_PortNumber    | 50000                           |
-      | TEST_NONXA                                | false                           |
-    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value db2 on XPath //*[local-name()='xa-datasource']/*[local-name()='driver']
-     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 127.0.0.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
-     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value bpms on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
-     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 50000 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
-     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 4 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DriverType"]
-     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value db2 on XPath //*[local-name()='database-data-store']/@database
 
   Scenario: Checks if the EJB Timer was successfully configured for an external DB2 datasource with Type 2 and env using XA connection properties
     When container is started with env


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fix https://issues.jboss.org/browse/RHPAM-1179

Behavioural changes:
* MySQL 
  * Allows receiving a `XA_CONNECTION_PROPERTY_URL` property
  * `PinGlobalTxToPhysicalConnection` is set using a property instead of the URL
* ServerName and PortNumber are assigned with the following preference:
  1. `DB_XA_CONNECTION_PROPERTY_ServerName`
  1. `DB_SERVICE_HOST`
  1. `DB_MYSQL_SERVICE_HOST`
* `NON_XA` is not forced: URL cannot be considered a valid XA property. Some drivers do not support it.
* URL is not taken from the NONXA configuration following the previous reasoning.
* Both options are configured in the same way. `DB_SERVICE_PREFIX_MAPPING` and `DATASOURCES`
* Removed configuration already set by the EAP datasource scripts.
* Removed custom configurations for `db2` and `postgresql`