### PR TITLE
[RHDM-670_RHPAM-1505] protect KIE_SERVER_ID from non-alphanumeric chars

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -422,8 +422,8 @@ function configure_kie_server_mgmt() {
 }
 
 function configure_server_state() {
-    # Need to replace whitespaces with something different from space or escaped space (\ ) characters
-    local kieServerId="${KIE_SERVER_ID// /_}"
+    # replace all non-alphanumeric characters with an underscore
+    local kieServerId="${KIE_SERVER_ID//[^[:alpha:].-]/_}"
     if [ "${kieServerId}" = "" ]; then
         if [ "x${HOSTNAME}" != "x" ]; then
             # chop off trailing unique "dash number" so all servers use the same template


### PR DESCRIPTION
[RHDM-670_RHPAM-1505] protect KIE_SERVER_ID from non-alphanumeric chars
https://issues.jboss.org/browse/RHDM-670
https://issues.jboss.org/browse/RHPAM-1505

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
