### PR TITLE
[KIECLOUD-14] Malformed Kie server id in case it contains number

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -422,9 +422,20 @@ function configure_kie_server_mgmt() {
 }
 
 function configure_server_state() {
-    # replace all non-alphanumeric characters with an underscore
-    local kieServerId="${KIE_SERVER_ID//[^[:alpha:].-]/_}"
-    if [ "${kieServerId}" = "" ]; then
+    # replace all non-alphanumeric characters with a dash
+    local kieServerId="${KIE_SERVER_ID//[^[:alnum:].-]/-}"
+    if [ "x${kieServerId}" != "x" ]; then
+        # can't start with a dash
+        local firstChar="$(echo -n $kieServerId | head -c 1)"
+        if [ "${firstChar}" = "-" ]; then
+            kieServerId="0${kieServerId}"
+        fi
+        # can't end with a dash
+        local lastChar="$(echo -n $kieServerId | tail -c 1)"
+        if [ "${lastChar}" = "-" ]; then
+            kieServerId="${kieServerId}0"
+        fi
+    else
         if [ "x${HOSTNAME}" != "x" ]; then
             # chop off trailing unique "dash number" so all servers use the same template
             kieServerId=$(echo "${HOSTNAME}" | sed -e 's/\(.*\)-[[:digit:]]\+-.*/\1/')


### PR DESCRIPTION
[KIECLOUD-14] Malformed Kie server id in case it contains number
https://issues.jboss.org/browse/KIECLOUD-14

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
