### PR TITLE
[KIECLOUD-20] revert to external route for org.kie.server.location

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -283,18 +283,18 @@ function configure_server_location() {
     # - name: HOSTNAME_HTTPS
     #   value: "${KIE_SERVER_HOSTNAME_HTTPS}"
     #
-#    local routeName="${KIE_SERVER_ROUTE_NAME}"
-#    local routeProtocol="http"
-#    local routeHost="${HOSTNAME_HTTP:-${HOSTNAME:-localhost}}"
-#    local routePort="80"
-#    if [ "${KIE_SERVER_USE_SECURE_ROUTE_NAME^^}" = "TRUE" ]; then
-#        routeName="secure-${routeName}"
-#        routeProtocol="https"
-#        routeHost="${HOSTNAME_HTTPS:-${routeHost}}"
-#        routePort="443"
-#    fi
-#    local routeUrl=$(build_route_url "${routeName}" "${routeProtocol}" "${routeHost}" "${routePort}" "/services/rest/server")
-#    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.location=${routeUrl}"
+    local routeName="${KIE_SERVER_ROUTE_NAME}"
+    local routeProtocol="http"
+    local routeHost="${HOSTNAME_HTTP:-${HOSTNAME:-localhost}}"
+    local routePort="80"
+    if [ "${KIE_SERVER_USE_SECURE_ROUTE_NAME^^}" = "TRUE" ]; then
+        routeName="secure-${routeName}"
+        routeProtocol="https"
+        routeHost="${HOSTNAME_HTTPS:-${routeHost}}"
+        routePort="443"
+    fi
+    local routeUrl=$(build_route_url "${routeName}" "${routeProtocol}" "${routeHost}" "${routePort}" "/services/rest/server")
+    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.location=${routeUrl}"
 
     # ---------- INTERNAL POD LOCATION ----------
     # Internal location of each KIE Server per each Pod's IP (retrieved via the Downward API).
@@ -305,11 +305,11 @@ function configure_server_location() {
     #     fieldRef:
     #       fieldPath: status.podIP
     #
-    local podProtocol="http"
-    local podHost="${KIE_SERVER_HOST:-${HOSTNAME:-localhost}}"
-    local podPort="8080"
-    local podUrl=$(build_simple_url "${podProtocol}" "${podHost}" "${podPort}" "/services/rest/server")
-    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.location=${podUrl}"
+#    local podProtocol="http"
+#    local podHost="${KIE_SERVER_HOST:-${HOSTNAME:-localhost}}"
+#    local podPort="8080"
+#    local podUrl=$(build_simple_url "${podProtocol}" "${podHost}" "${podPort}" "/services/rest/server")
+#    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.location=${podUrl}"
 }
 
 function configure_server_persistence() {


### PR DESCRIPTION
[KIECLOUD-20] revert to external route for org.kie.server.location
https://issues.jboss.org/browse/KIECLOUD-20

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
