### PR TITLE
[RHPAM-1561] Add https support to smart-router for cloud (master)

### DIFF
--- a/jboss-kie-smartrouter/added/launch/jboss-kie-smartrouter.sh
+++ b/jboss-kie-smartrouter/added/launch/jboss-kie-smartrouter.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source "${LAUNCH_DIR}/launch-common.sh"
+source "${LAUNCH_DIR}/logging.sh"
 
 function prepareEnv() {
     # please keep these in alphabetical order
@@ -19,6 +20,11 @@ function prepareEnv() {
     unset KIE_SERVER_ROUTER_URL_EXTERNAL
     unset KIE_SERVER_ROUTER_REPO
     unset KIE_SERVER_ROUTER_CONFIG_WATCHER_ENABLED
+    unset KIE_SERVER_ROUTER_TLS_KEYSTORE
+    unset KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD
+    unset KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS
+    unset KIE_SERVER_ROUTER_PORT_TLS
+    unset KIE_SERVER_ROUTER_TLS_TEST
 }
 
 function configureEnv() {
@@ -29,6 +35,7 @@ function configure() {
     configure_router_state
     configure_router_location
     configure_controller_access
+    configure_router_tls
 }
 
 function configure_router_state() {
@@ -140,6 +147,50 @@ function configure_controller_access {
     if [ "${kieServerControllerToken}" != "" ]; then
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.token=\"${kieServerControllerToken}\""
     fi
+}
+
+function configure_router_tls() {
+    # If the path, alias, or password is empty exit early and skip https
+    if [ -z "${KIE_SERVER_ROUTER_TLS_KEYSTORE}" ] || \
+       [ -z "${KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS}" ] || \
+       [ -z "${KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD}" ]; then
+        log_warning "Missing value for TLS keystore path, alias, or password, skipping https setup"
+	return
+    fi
+
+    # generate a keystore for cekit test if the test flag is true and we are not running in OpenShift
+    # and there is no keystore file at the designated path
+    if [ "${KIE_SERVER_ROUTER_TLS_TEST}" == "true" ] && [ -z "${KUBERNETES_SERVICE_HOST}" ] && ! [ -f "${KIE_SERVER_ROUTER_TLS_KEYSTORE}" ]; then
+        log_warning "Container is in test mode and not in OpenShift, generating test certificate"
+        keytool -genkey -alias jboss -keyalg RSA -keystore /tmp/keystore.jks -storepass mykeystorepass -keypass mykeystorepass -dname CN=bob
+        KIE_SERVER_ROUTER_TLS_KEYSTORE=/tmp/keystore.jks
+    fi
+
+    # Allow for optional volume mount or empty secret
+    if ! [ -f "${KIE_SERVER_ROUTER_TLS_KEYSTORE}" ]; then
+	log_warning "Keystore file ${KIE_SERVER_ROUTER_TLS_KEYSTORE} not found or not a regular file, skipping https setup"
+	return
+    fi
+
+    # If the keystore is not readable, smartrouter startup will throw an exception
+    # resulting in the http port being unavailable as well. So make sure ...
+    keytool -list -alias ${KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS} \
+	          -storepass ${KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD} \
+	          -keystore ${KIE_SERVER_ROUTER_TLS_KEYSTORE} &> /dev/null
+    if [ "$?" -ne 0 ]; then
+	log_warning "Unable to read TLS keystore, skipping https setup"
+	return
+    fi
+
+    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.router.tls.keystore=${KIE_SERVER_ROUTER_TLS_KEYSTORE}"
+    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.router.tls.keystore.keyalias=${KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS}"
+    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.router.tls.keystore.password=${KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD}"
+
+    local kieServerRouterPortTLS="${KIE_SERVER_ROUTER_PORT_TLS}"
+    if [ "${kieServerRouterPortTLS}" = "" ]; then
+        kieServerRouterPortTLS="9443"
+    fi
+    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.router.tls.port=${kieServerRouterPortTLS}"
 }
 
 function generate_random_id() {

--- a/tests/features/rhpam/smartrouter/rhpam-smartrouter.feature
+++ b/tests/features/rhpam/smartrouter/rhpam-smartrouter.feature
@@ -10,3 +10,79 @@ Feature: RHPAM Smart Router configuration tests
     When container is ready
     Then run sh -c 'echo $JBOSS_PRODUCT' in container and check its output for rhpam-smartrouter
      And run sh -c 'echo $RHPAM_SMARTROUTER_VERSION' in container and check its output for 7.3
+
+  # If KIE_SERVER_ROUTER_TLS_TEST is true the launch script will generate a certificate at /tmp/keystore.jks
+  # with key alias "jboss" and password "mykeystorepass" and reset KIE_SERVER_ROUTER_TLS_KEYSTORE to /tmp/keystore.jks
+  # This functionality is not available if KUBERNETES_SERVICE_HOST is set, i.e the container is running in OpenShift
+
+  Scenario: Verify the smart router TLS configuration, no conf provided
+    When container is ready
+    Then container log should contain Missing value for TLS keystore path, alias, or password, skipping https setup
+    And container log should match regex KieServerRouter started on.*9000 at
+    And container log should not contain Container is in test mode and not in OpenShift, generating test certificate
+
+  Scenario: Verify the smart router TLS configuration, test cert not generated and KIE_SERVER_ROUTER_TLS_KEYSTORE not found
+    When container is started with env
+      | variable                                 | value                            |
+      | KIE_SERVER_ROUTER_TLS_TEST               | false                            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE           | /etc/cert/certificate            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS  | jboss                            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD  | mykeystorepass                   |
+    Then container log should contain Keystore file /etc/cert/certificate not found or not a regular file, skipping https setup
+    And container log should match regex KieServerRouter started on.*9000 at
+    And container log should not contain Container is in test mode and not in OpenShift, generating test certificate
+
+  Scenario: Verify the smart router TLS configuration, test cert not generated because KUBERNETES_SERVICE_HOST defined
+    When container is started with env
+      | variable                                 | value                            |
+      | KIE_SERVER_ROUTER_TLS_TEST               | true                             |
+      | KUBERNETES_SERVICE_HOST                  | somevalue                        |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE           | /etc/cert/certificate            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS  | jboss                            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD  | mykeystorepass                   |
+    Then container log should contain Keystore file /etc/cert/certificate not found or not a regular file, skipping https setup
+    And container log should match regex KieServerRouter started on.*9000 at
+    And container log should not contain Container is in test mode and not in OpenShift, generating test certificate
+
+  Scenario: Verify the smart router TLS configuration, test cert not generated because keystore path exists
+    When container is started with env
+      | variable                                 | value                                      |
+      | KIE_SERVER_ROUTER_TLS_TEST               | true                                       |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE           | /opt/rhpam-smartrouter/openshift-launch.sh |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS  | jboss                                      |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD  | mykeystorepass                             |
+    Then container log should contain Unable to read TLS keystore, skipping https setup
+    And container log should match regex KieServerRouter started on.*9000 at
+    And container log should not contain Container is in test mode and not in OpenShift, generating test certificate
+
+  Scenario: Verify the smart router TLS configuration, incorrect user
+    When container is started with env
+      | variable                                 | value                            |
+      | KIE_SERVER_ROUTER_TLS_TEST               | true                             |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE           | /etc/cert/certificate            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS  | thisiswrong                      |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD  | mykeystorepass                   |
+    Then container log should contain Unable to read TLS keystore, skipping https setup
+    And container log should match regex KieServerRouter started on.*9000 at
+    And container log should contain Container is in test mode and not in OpenShift, generating test certificate
+
+  Scenario: Verify the smart router TLS configuration, incorrect password
+    When container is started with env
+      | variable                                 | value                            |
+      | KIE_SERVER_ROUTER_TLS_TEST               | true                             |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE           | /etc/cert/certificate            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS  | jboss                            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD  | thisiswrong                      |
+    Then container log should contain Unable to read TLS keystore, skipping https setup
+    And container log should match regex KieServerRouter started on.*9000 at
+    And container log should contain Container is in test mode and not in OpenShift, generating test certificate
+
+  Scenario: Verify the smart router TLS configuration, everything correct
+    When container is started with env
+      | variable                                 | value                            |
+      | KIE_SERVER_ROUTER_TLS_TEST               | true                             |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE           | /etc/cert/certificate            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_KEYALIAS  | jboss                            |
+      | KIE_SERVER_ROUTER_TLS_KEYSTORE_PASSWORD  | mykeystorepass                   |
+    Then container log should match regex KieServerRouter started on.*9000 and .*9443 \(TLS\) at
+    And container log should contain Container is in test mode and not in OpenShift, generating test certificate


### PR DESCRIPTION
https://issues.jboss.org/browse/RHPAM-1561
Smart router currently only supports http. To run this tool in production environments, https support is required. This is added for on-premise, needs to be added to cloud images / templates as well.

Signed-off-by: Trevor McKay <tmckay@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
