### PR TITLE
[KIECLOUD-34] APPFORMER_JMS_BROKER_USER isn't evaluated in scripts

### DIFF
--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -148,7 +148,7 @@ function configure_ha() {
     if [ "${JGROUPS_PING_PROTOCOL}" = "openshift.DNS_PING" ]; then
         if [ -n "${OPENSHIFT_DNS_PING_SERVICE_NAME}" -a -n "${OPENSHIFT_DNS_PING_SERVICE_PORT}" ]; then
             log_info "OpenShift DNS_PING protocol envs set, verifying other needed envs for HA setup. Using ${JGROUPS_PING_PROTOCOL}"
-            local jmsBrokerUsername="${APPFORMER_JMS_BROKER_USERNAME:-APPFORMER_JMS_BROKER_USER}"
+            local jmsBrokerUsername="${APPFORMER_JMS_BROKER_USERNAME:-$APPFORMER_JMS_BROKER_USER}"
             if [ -n "$APPFORMER_ELASTIC_HOST" -a -n "$jmsBrokerUsername" -a -n "$APPFORMER_JMS_BROKER_PASSWORD" -a -n "$APPFORMER_JMS_BROKER_ADDRESS" ] ; then
                 # set the workbench properties for HA
                 local jmsConnectionParams="${APPFORMER_JMS_CONNECTION_PARAMS:-ha=true&retryInterval=1000&retryIntervalMultiplier=1.0&reconnectAttempts=-1}"

--- a/tests/features/processserver/processserver_6_4.feature
+++ b/tests/features/processserver/processserver_6_4.feature
@@ -1,4 +1,4 @@
-@jboss-processserver-6/processserver64-openshift @wip
+@jboss-processserver-6/processserver64-openshift
 Feature: OpenShift Process Server 6.4 basic tests
 
   Scenario: Check for add-user failures


### PR DESCRIPTION
[KIECLOUD-34] APPFORMER_JMS_BROKER_USER isn't evaluated in scripts
https://issues.jboss.org/browse/KIECLOUD-34

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
