### PR TITLE
little improvements

### DIFF
--- a/tools/openshift-template-validator/bash-completion.sh
+++ b/tools/openshift-template-validator/bash-completion.sh
@@ -6,7 +6,7 @@ _validator_completions() {
     showOnlyOne="${COMP_WORDS[1]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     opts="validate help"
-    allOpts="--file --dir --persist --custom-annotation --template-version --validate-version --verbose --strict --dump --help"
+    allOpts="--file --dir --persist --custom-annotation --template-version --validate-version --verbose --strict --dump --help --disable-defer"
 
     case "${prev}" in
         validate)

--- a/tools/openshift-template-validator/cli/validateCommand.go
+++ b/tools/openshift-template-validator/cli/validateCommand.go
@@ -63,6 +63,11 @@ var ValidateCommand = cli.Command{
 			Usage:       "Dump all parsed template parameters.",
 			Destination: &utils.DumpParameters,
 		},
+		cli.BoolFlag{
+			Name:        "disable-defer",
+			Usage:       "Disable defer which recover from panic for troubleshooting purposes.",
+			Destination: &utils.DisableDefer,
+		},
 	},
 	Action: func(c *cli.Context) error {
 

--- a/tools/openshift-template-validator/utils/utils.go
+++ b/tools/openshift-template-validator/utils/utils.go
@@ -20,6 +20,7 @@ var (
 	Persist                 bool
 	Strict                  bool
 	ValidateTemplateVersion bool
+	DisableDefer			bool
 	RequiredAnnotations     = []string{"iconClass", "openshift.io/display-name", "tags", "version", "description", "openshift.io/provider-display-name",
 		"template.openshift.io/documentation-url", "template.openshift.io/support-url", "template.openshift.io/long-description", "template.openshift.io/bindable"}
 	RequiredImageStreamAnnotations = []string{"description", "iconClass", "tags", "supports", "version"}
@@ -69,9 +70,9 @@ func In_array(a []string, value string) bool {
 }
 
 func RecoverFromPanic() {
-	if r := recover(); r != nil {
+	if r := recover(); r != nil && !DisableDefer {
 		if Debug {
-			fmt.Println("recovered from ", r)
+			fmt.Println("\nPanic-----recovered from ", r)
 		}
 	}
 }


### PR DESCRIPTION
fix container slice boundary, if there is no container.Ports the validation will fail if verbose is enabled.
make the defer configurable, user can now disable the app to recover from panic by using the flag --disable-defer.

Signed-off-by: Filippe Spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
