### PR TITLE
[KIECLOUD-123] expose MAVEN_MIRROR_URL parameter in authoring templates

### DIFF
--- a/tests/features/common/kie-common.feature
+++ b/tests/features/common/kie-common.feature
@@ -63,3 +63,12 @@ Feature: RHPAM and RHDM common tests
       | variable   | value |
       | KIE_MBEANS | false |
     Then container log should contain -Dkie.mbeans=disabled -Dkie.scanner.mbeans=disabled
+
+  Scenario: test MAVEN_MIRROR_URL configuration
+    When container is started with env
+      | variable         | value                                     |
+      | MAVEN_MIRROR_URL | http://nexus-test.127.0.0.1.nip.ip/nexus/ |
+    Given XML namespaces
+       | prefix | url                                    |
+       | ns     | http://maven.apache.org/SETTINGS/1.0.0 |
+    Then XML file /home/jboss/.m2/settings.xml should have 1 elements on XPath //ns:mirror[ns:id='mirror.default'][ns:url='http://nexus-test.127.0.0.1.nip.ip/nexus/'][ns:mirrorOf='external:*']


### PR DESCRIPTION
[KIECLOUD-123] expose MAVEN_MIRROR_URL parameter in authoring templates
https://issues.jboss.org/browse/KIECLOUD-123

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
