### PR TITLE
[KIECLOUD-134] (7.3.0) Enhance KieServerStateOpenShiftRepository - Fixing naming issue

### DIFF
--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -21,14 +21,14 @@ function prepareEnv() {
     unset APPFORMER_JMS_BROKER_USERNAME
     unset APPFORMER_JMS_CONNECTION_PARAMS
     unset GIT_HOOKS_DIR
-    unset KIE_CONTROLLER_OCP_ENABLED
-    unset KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
-    unset KIE_CONTROLLER_TEMPLATE_CACHE_TTL
     unset_kie_security_env
     unset KIE_SERVER_CONTROLLER_HOST
+    unset KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
     unset KIE_SERVER_CONTROLLER_PORT
     unset KIE_SERVER_CONTROLLER_PROTOCOL
     unset KIE_SERVER_CONTROLLER_SERVICE
+    unset KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
+    unset KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
 }
 
 function configureEnv() {
@@ -114,13 +114,13 @@ function configure_server_access() {
 }
 
 function configure_openshift_enhancement() {
-    local kscOpenShiftEnabled=$(find_env "KIE_CONTROLLER_OCP_ENABLED" "false")
-    local kscPreferKieService=$(find_env "KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE" "false")
-    local kscTemplateCacheTTL=$(find_env "KIE_CONTROLLER_TEMPLATE_CACHE_TTL" "60000")
+    local kscPreferKieService=$(find_env "KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE" "false")
+    local kscTemplateCacheTTL=$(find_env "KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL" "60000")
+    local kscOpenShiftEnabled=$(find_env "KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED" "false")
 
-    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.workbench.controller.openshift.enabled=${kscOpenShiftEnabled}"
     JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.openshift.prefer.kieserver.service=${kscPreferKieService}"
     JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.template.cache.ttl=${kscTemplateCacheTTL}"
+    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.workbench.controller.openshift.enabled=${kscOpenShiftEnabled}"
 }
 
 function configure_workbench_profile() {

--- a/tests/features/rhpam/businesscentral-monitoring/rhpam-businesscentral-monitoring.feature
+++ b/tests/features/rhpam/businesscentral-monitoring/rhpam-businesscentral-monitoring.feature
@@ -51,14 +51,14 @@ Feature: RHPAM Business Central Monitoring configuration tests
     Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <login-module code="org.kie.security.jaas.KieLoginModule"
 
   # https://issues.jboss.org/browse/JBPM-7834
+  # https://issues.jboss.org/projects/JBPM/issues/JBPM-8269
   Scenario: Check OpenShiftStartupStrategy is enabled in RHPAM 7
     When container is started with env
-      | variable                                          | value                     |
-      | KIE_CONTROLLER_OCP_ENABLED                        | true                      |
-      | KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE | false                     |
-      | KIE_CONTROLLER_TEMPLATE_CACHE_TTL                 | 60000                     |
-   Then container log should contain -Dorg.kie.workbench.controller.openshift.enabled=true
-   Then container log should contain -Dorg.kie.server.controller.openshift.prefer.kieserver.service=false
-   Then container log should contain -Dorg.kie.server.controller.template.cache.ttl=60000
-
+      | variable                                                 | value                     |
+      | KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE | true                      |
+      | KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL                 | 10000                     |
+      | KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED               | true                      |
+    Then container log should contain -Dorg.kie.server.controller.openshift.prefer.kieserver.service=true
+    Then container log should contain -Dorg.kie.server.controller.template.cache.ttl=10000
+    Then container log should contain -Dorg.kie.workbench.controller.openshift.enabled=true
 

--- a/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
+++ b/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
@@ -51,15 +51,16 @@ Feature: RHPAM Business Central configuration tests
     Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <login-module code="org.kie.security.jaas.KieLoginModule"
 
   # https://issues.jboss.org/browse/JBPM-7834
+  # https://issues.jboss.org/projects/JBPM/issues/JBPM-8269
   Scenario: Check OpenShiftStartupStrategy is enabled in RHPAM 7
     When container is started with env
-      | variable                                          | value                     |
-      | KIE_CONTROLLER_OCP_ENABLED                        | true                      |
-      | KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE | false                     |
-      | KIE_CONTROLLER_TEMPLATE_CACHE_TTL                 | 60000                     |
-   Then container log should contain -Dorg.kie.workbench.controller.openshift.enabled=true
-   Then container log should contain -Dorg.kie.server.controller.openshift.prefer.kieserver.service=false
-   Then container log should contain -Dorg.kie.server.controller.template.cache.ttl=60000
+      | variable                                                 | value                     |
+      | KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE | true                      |
+      | KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL                 | 10000                     |
+      | KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED               | true                      |
+    Then container log should contain -Dorg.kie.server.controller.openshift.prefer.kieserver.service=true
+    Then container log should contain -Dorg.kie.server.controller.template.cache.ttl=10000
+    Then container log should contain -Dorg.kie.workbench.controller.openshift.enabled=true
 
   # https://issues.jboss.org/browse/RHDM-871
   Scenario: Check Workbench profile for rhpam


### PR DESCRIPTION
Adding a runtime configuration parameter in terms of system property and environment variable for enabling BC/WB KIE server global discovery.

Related JIRA

https://issues.jboss.org/browse/KIECLOUD-134
https://issues.jboss.org/projects/JBPM/issues/JBPM-8269

- [x] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
