### PR TITLE
KIECLOUD-134] (7.3.1) Enhance KieServerStateOpenShiftRepository - Adding global discovery switch

### DIFF
--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -23,6 +23,7 @@ function prepareEnv() {
     unset GIT_HOOKS_DIR
     unset_kie_security_env
     unset KIE_SERVER_CONTROLLER_HOST
+    unset KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
     unset KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
     unset KIE_SERVER_CONTROLLER_PORT
     unset KIE_SERVER_CONTROLLER_PROTOCOL
@@ -114,10 +115,12 @@ function configure_server_access() {
 }
 
 function configure_openshift_enhancement() {
+    local kscGlobalDiscoveryEnabled=$(find_env "KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED" "false")
     local kscPreferKieService=$(find_env "KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE" "false")
     local kscTemplateCacheTTL=$(find_env "KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL" "60000")
     local kscOpenShiftEnabled=$(find_env "KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED" "false")
 
+    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.openshift.global.discovery.enabled=${kscGlobalDiscoveryEnabled}"
     JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.openshift.prefer.kieserver.service=${kscPreferKieService}"
     JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.template.cache.ttl=${kscTemplateCacheTTL}"
     JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.workbench.controller.openshift.enabled=${kscOpenShiftEnabled}"

--- a/tests/features/rhpam/businesscentral-monitoring/rhpam-businesscentral-monitoring.feature
+++ b/tests/features/rhpam/businesscentral-monitoring/rhpam-businesscentral-monitoring.feature
@@ -55,10 +55,11 @@ Feature: RHPAM Business Central Monitoring configuration tests
   Scenario: Check OpenShiftStartupStrategy is enabled in RHPAM 7
     When container is started with env
       | variable                                                 | value                     |
+      | KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED | true                      |
       | KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE | true                      |
       | KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL                 | 10000                     |
       | KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED               | true                      |
+    Then container log should contain -Dorg.kie.server.controller.openshift.global.discovery.enabled=true
     Then container log should contain -Dorg.kie.server.controller.openshift.prefer.kieserver.service=true
     Then container log should contain -Dorg.kie.server.controller.template.cache.ttl=10000
     Then container log should contain -Dorg.kie.workbench.controller.openshift.enabled=true
-

--- a/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
+++ b/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
@@ -55,9 +55,11 @@ Feature: RHPAM Business Central configuration tests
   Scenario: Check OpenShiftStartupStrategy is enabled in RHPAM 7
     When container is started with env
       | variable                                                 | value                     |
+      | KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED | true                      |
       | KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE | true                      |
       | KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL                 | 10000                     |
       | KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED               | true                      |
+    Then container log should contain -Dorg.kie.server.controller.openshift.global.discovery.enabled=true
     Then container log should contain -Dorg.kie.server.controller.openshift.prefer.kieserver.service=true
     Then container log should contain -Dorg.kie.server.controller.template.cache.ttl=10000
     Then container log should contain -Dorg.kie.workbench.controller.openshift.enabled=true


### PR DESCRIPTION
Adding a runtime configuration parameter in terms of system property and environment variable for enabling BC/WB KIE server global discovery.

Related JIRA

https://issues.jboss.org/browse/KIECLOUD-134
https://issues.jboss.org/projects/JBPM/issues/JBPM-8269

- [x] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
