### PR TITLE
old httpclient library in arquillian tests causes github security warning

### DIFF
--- a/tests/arquillian/kieserver/pom.xml
+++ b/tests/arquillian/kieserver/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
 
-        <version.org.apache.httpclient>4.3.3</version.org.apache.httpclient>
+        <version.org.apache.httpclient>4.3.6</version.org.apache.httpclient>
         <version.org.arquillian.cube>1.18.1</version.org.arquillian.cube>
         <version.org.jboss.as.arquillian.container>7.2.0.Final</version.org.jboss.as.arquillian.container>
         <version.org.jboss.logging>3.3.1.Final-redhat-1</version.org.jboss.logging>


### PR DESCRIPTION
old httpclient library in arquillian tests causes github security warning
https://issues.jboss.org/browse/KIECLOUD-156

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
