### PR TITLE
[KIECLOUD-184] RHPAM OpenShiftStartupStrategy Full Release

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -252,6 +252,8 @@ function configure_controller_access {
     local kieServerControllerService="${KIE_SERVER_CONTROLLER_SERVICE}"
     kieServerControllerService=${kieServerControllerService^^}
     kieServerControllerService=${kieServerControllerService//-/_}
+    # token
+    local kieServerControllerToken="$(get_kie_server_controller_token)"
     # host
     local kieServerControllerHost="${KIE_SERVER_CONTROLLER_HOST}"
     if [ "${kieServerControllerHost}" = "" ]; then
@@ -273,14 +275,13 @@ function configure_controller_access {
         # url
         local kieServerControllerUrl=$(build_simple_url "${kieServerControllerProtocol}" "${kieServerControllerHost}" "${kieServerControllerPort}" "${kieServerControllerPath}")
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller=${kieServerControllerUrl}"
-    fi
-    # user/pwd
-    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.user=\"$(get_kie_server_controller_user)\""
-    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.pwd=\"$(esc_kie_server_controller_pwd)\""
-    # token
-    local kieServerControllerToken="$(get_kie_server_controller_token)"
-    if [ "${kieServerControllerToken}" != "" ]; then
-        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.token=\"${kieServerControllerToken}\""
+        # user/pwd
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.user=\"$(get_kie_server_controller_user)\""
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.pwd=\"$(esc_kie_server_controller_pwd)\""
+        # token
+        if [ "${kieServerControllerToken}" != "" ]; then
+            JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.token=\"${kieServerControllerToken}\""
+        fi
     fi
 }
 

--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -93,6 +93,8 @@ function configure_controller_access {
     local kieServerControllerService="${KIE_SERVER_CONTROLLER_SERVICE}"
     kieServerControllerService=${kieServerControllerService^^}
     kieServerControllerService=${kieServerControllerService//-/_}
+    # token
+    local kieServerControllerToken="$(get_kie_server_controller_token)"
     # host
     local kieServerControllerHost="${KIE_SERVER_CONTROLLER_HOST}"
     if [ "${kieServerControllerHost}" = "" ]; then
@@ -114,14 +116,13 @@ function configure_controller_access {
         # url
         local kieServerControllerUrl=$(build_simple_url "${kieSererControllerProtocol}" "${kieServerControllerHost}" "${kieServerControllerPort}" "${kieServerControllerPath}")
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller=${kieServerControllerUrl}"
-    fi
-    # user/pwd
-    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.user=\"$(get_kie_server_controller_user)\""
-    JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.pwd=\"$(esc_kie_server_controller_pwd)\""
-    # token
-    local kieServerControllerToken="$(get_kie_server_controller_token)"
-    if [ "${kieServerControllerToken}" != "" ]; then
-        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.token=\"${kieServerControllerToken}\""
+        # user/pwd
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.user=\"$(get_kie_server_controller_user)\""
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.pwd=\"$(esc_kie_server_controller_pwd)\""
+        # token
+        if [ "${kieServerControllerToken}" != "" ]; then
+            JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.controller.token=\"${kieServerControllerToken}\""
+        fi
     fi
 }
 


### PR DESCRIPTION
As part of making OpenShiftStartupStrategy as the default for KIE Server, KIE Server Controller related system properties should **NOT** be configured so as to avoid confusion and unexpected behavior.
For compatibility, in the Templates, Controller User and Pwd parameters needs to be kept still in that BC/WB requires those value to seed the controller user for EmbeddedController (i.e. add_kie_server_controller_user) by image scripts. However, there is no need for OSSS enabled KIE Server to have such environment variables. In addition, there is no need for BC/WB and OSSS enabled KIE Server to have controllerUser and controllerPwd defined as Java system properties. As a result, the changes from this PR make use of {KIE_SERVER_CONTROLLER_SERVICE} as the master condition. Both BC/WB and OSSS enabled KIE Server Pod/Template will NOT have that environment variable defined, in turn, system properties will be cleaned up.

Related JIRA
https://issues.jboss.org/projects/KIECLOUD/issues/KIECLOUD-184

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
