### PR TITLE
[BAPL-1072] Add build-osbs.sh script for cekit/osbs image builds (7.3.x)

### DIFF
--- a/tools/build-osbs/build-osbs.sh
+++ b/tools/build-osbs/build-osbs.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+
+set -e
+
+DEBUG=
+GIT_USER=${GIT_USER:-"Your Name"}
+GIT_EMAIL=${GIT_EMAIL:-"yourname@email.com"}
+WORK_DIR=$(pwd)/build-temp
+
+function help()
+{
+    echo "usage: build-osbs.sh [options]"
+    echo
+    echo "Run a cekit osbs build of an rhba image component based on a nightly build of the upstream kie repos"
+    echo
+    echo "For each of the options below, the names of the arguments are environment variables that may be set"
+    echo "instead of using the particular option on the invocation"
+    echo ""
+    echo "Required:"
+    echo "  -v PROD_VERSION           Version being built. Passed to the build-overrides.sh -v option"
+    echo "  -c PROD_COMPONENT         Component for which an image is being built. Valid choices are:"
+    echo "                            rhpam-businesscentral, rhpam-businesscentral-monitoring, rhpam-businesscentral-indexing,"
+    echo "                            rhpam-controller, rhpam-kieserver, rhpam-smartrouter, rhdm-decisioncentral,"
+    echo "                            rhdm-decisioncentral-indexing, rhdm-controller, rhdm-kieserver, rhdm-optaweb-employee-rostering"
+    echo "  -t OSBS_BUILD_TARGET      Build target for osbs, for example rhba-7.3-openshift-containers-candidate"
+    echo ""
+    echo "Optional:"
+    echo "  -h                        Print this help message"
+    echo "  -p KERBEROS_PRINCIPAL     Kerberos principal to use with to access build systems. If not specified,"
+    echo "                            the script assumes there is a valid kerberos ticket in force. If it is specified"
+    echo "                            then one of KERBEROS_KEYTAB or KERBEROS_PASSWORD is required."
+    echo "  -k KERBEROS_KEYTAB        Path to a keytab file for KERBEROS_PRINCIPAL if no KERBEROS_PASSWORD is specified."
+    echo "  -s KERBEROS_PASSWORD      Password for KERBEROS_PRINCIPAL (a keytab file may be used instead via KERBEROS_KEYTAB)"
+    echo "  -i OSBS_BUILD_USER        Maps to the build-osbs-user option for cekit (ie the user for rhpkg commands)"
+    echo "                            The default will be KERBEROS_PRINCIPAL if this is not set"
+    echo "  -b BUILD_DATE             The date of the nightly build to access. Passed to the build-overrides.sh -b option if set"
+    echo "  -w WORK_DIR               The working directory used for generating overrides, cekit cache, etc. Default is ./build-temp."
+    echo "  -u GIT_USER               User config for git commits to internal repositories. Default is 'Your Name'"
+    echo "  -e GIT_EMAIL              Email config for git commits to internal repositories. Default is 'yourname@email.com'"
+    echo "  -o CEKIT_BUILD_OPTIONS    Additional options to pass through to the cekit build command, should be quoted"
+    echo "  -l CEKIT_CACHE_LOCAL      Comma-separated list of urls to download and add to the local cekit cache"
+    echo "  -g                        Debug setting, currently sets verbose flag on cekit commands"
+}
+
+
+function get_short_version() {
+  local version_array
+  local short_version=$1
+  IFS='.' read -r -a version_array <<< "$1"
+  if [ ${#version_array[@]} -gt 1 ]; then
+      short_version="${version_array[0]}.${version_array[1]}"
+  fi
+  echo $short_version
+}
+
+function check_for_required_envs()
+{
+    if [ -z "$GIT_EMAIL" ]; then
+        echo "No git email specified with GIT_EMAIL"
+        exit -1
+    fi
+    if [ -z "$GIT_USER" ]; then
+        echo "No git user specified with GIT_USER"
+        exit -1
+    fi
+    if [ -z "$PROD_VERSION" ]; then
+        echo "No version specified with PROD_VERSION"
+        exit -1
+    fi
+    if [ -z "$PROD_COMPONENT" ]; then
+        echo "No component specified with PROD_COMPONENT"
+        exit -1
+    else
+        case "$PROD_COMPONENT" in
+            rhpam-businesscentral | \
+            rhpam-businesscentral-indexing | \
+            rhpam-businesscentral-monitoring | \
+            rhpam-controller | \
+            rhpam-kieserver | \
+            rhpam-smartrouter | \
+	    rhdm-controller | \
+	    rhdm-decisioncentral | \
+	    rhdm-decisioncentral-indexing | \
+	    rhdm-kieserver | \
+	    rhdm-optaweb-employee-rostering)
+                ;;
+            *)
+                echo Invalid subcomponent specified with PROD_COMPONENT
+                exit -1
+                ;;
+        esac
+    fi
+    if [ -z "$OSBS_BUILD_TARGET" ]; then
+        echo "No build target specified with OSBS_BUILD_TARGET"
+        exit -1
+    fi
+}
+
+function get_kerb_ticket() {
+    set +e
+    if [ -n "$KERBEROS_PASSWORD" ]; then
+        echo "$KERBEROS_PASSWORD" | kinit "$KERBEROS_PRINCIPAL"
+        if [ "$?" -ne 0 ]; then
+            echo "Failed to get kerberos token for $KERBEROS_PRINCIPAL with password"
+            exit -1
+        fi
+    elif [ -n "$KERBEROS_KEYTAB" ]; then
+        kinit -k -t "$KERBEROS_KEYTAB" "$KERBEROS_PRINCIPAL"
+        if [ "$?" -ne 0 ]; then
+            echo "Failed to get kerberos token for $KERBEROS_PRINCIPAL with $KERBEROS_KEYTAB"
+            exit -1
+        fi
+    else
+        echo "No kerberos password or keytab specified with KERBEROS_PASSWORD or KERBEROS_KEYTAB"
+        exit -1
+    fi
+    set -e
+}
+
+function set_git_config()
+{
+    git config --global user.email "$GIT_EMAIL"
+    git config --global user.name  "$GIT_USER"
+    git config --global core.pager ""
+}
+
+function get_extra_cekit_overrides_options()
+{
+    local gen_overrides_dir=$1
+    overrides=
+    extraoverrides=
+
+    if [ -f "$gen_overrides_dir/$PROD_COMPONENT-overrides.yaml" ]; then
+        overrides="--overrides-file $gen_overrides_dir/$PROD_COMPONENT-overrides.yaml"
+    fi
+
+    # If we have an additional overrides file included for a particular branch and a particular
+    # component that we're building, then add that extra file
+    local sv=$(get_short_version $PROD_VERSION)
+    if [ -f "/opt/rhba/overrides/$sv/$PROD_COMPONENT-overrides.yaml" ]; then
+	extraoverrides="--overrides-file /opt/rhba/overrides/$sv/$PROD_COMPONENT-overrides.yaml"
+    fi
+}
+
+function handle_cache_urls()
+{
+    # See if there is a file for this version/component stored with the overrides that specifies urls to cache
+    # the overrides directory is organized by short branch names
+    local branch_name="$(git symbolic-ref HEAD 2>/dev/null)"
+    branch_name=${branch_name##refs/heads/}
+
+    local sv=$(get_short_version $branch_name)
+    if [ -f "/opt/rhba/overrides/$sv/$PROD_COMPONENT-cache-local.sh" ]; then
+        echo build-overrides.sh -C /opt/rhba/overrides/$sv/$PROD_COMPONENT-cache-local.sh $bo_options
+        build-overrides.sh -C /opt/rhba/overrides/$sv/$PROD_COMPONENT-cache-local.sh $bo_options
+    fi
+
+    # Parse and cache extra urls to add to the local cekit cache
+    if [ -n "$1" ]; then
+        local IFS=,
+        local urllist=($1)
+        for url in "${urllist[@]}"; do
+            echo build-overrides.sh -c $url $bo_options
+            build-overrides.sh -c $url $bo_options
+        done
+    fi
+}
+
+function generate_overrides_files()
+{
+    # build-overrides.sh doesn't support indexing images as a product value
+    if [ "$PROD_COMPONENT" == "rhdm-decisioncentral-indexing" -o "$PROD_COMPONENT" == "rhpam-businesscentral-indexing" ]; then
+        return
+    fi
+
+    echo build-overrides.sh -v $PROD_VERSION -t nightly -p $PROD_COMPONENT $bo_options
+    build-overrides.sh -v $PROD_VERSION -t nightly -p $PROD_COMPONENT $bo_options
+}
+
+while getopts gu:e:v:c:t:o:r:n:d:p:k:s:b:l:i:w:h option; do
+    case $option in
+        g)
+            DEBUG=true
+            ;;
+        u)
+            GIT_USER=$OPTARG
+            ;;
+        e)
+            GIT_EMAIL=$OPTARG
+            ;;
+        v)
+            PROD_VERSION=$OPTARG
+            ;;
+        c)
+            PROD_COMPONENT=$OPTARG
+            ;;
+        t)
+            OSBS_BUILD_TARGET=$OPTARG
+            ;;
+        o)
+            CEKIT_BUILD_OPTIONS=$OPTARG
+            ;;
+        p)
+            KERBEROS_PRINCIPAL=$OPTARG
+            ;;
+        k)
+            KERBEROS_KEYTAB=$OPTARG
+            ;;
+        s)
+            KERBEROS_PASSWORD=$OPTARG
+            ;;
+        b)
+            BUILD_DATE=$OPTARG
+            ;;
+	l)
+	    CEKIT_CACHE_LOCAL=$OPTARG
+	    ;;
+	i)
+	    OSBS_BUILD_USER=$OPTARG
+	    ;;
+	w)
+	    WORK_DIR=$OPTARG
+	    ;;
+        h)
+            help
+            exit 0
+            ;;
+        *)
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+mkdir -p $WORK_DIR
+
+# Make sure we have build-overrides.sh on our path
+set +e
+$(command -v "build-overrides.sh" &> /dev/null)
+res=$?
+set -e
+if [ "$res" -ne 0 ]; then
+    echo No build-overrides.sh found on the current path, it needs to be added
+    exit -1
+fi
+
+# Set common options for build-overrides.sh calls
+cekit_cache_dir="$WORK_DIR/.cekit"
+gen_overrides_dir="$WORK_DIR/build-overrides"
+bo_options="-w $cekit_cache_dir -d $gen_overrides_dir"
+if [ -n "$BUILD_DATE" ]; then
+    bo_options+=" -b $BUILD_DATE"
+fi
+
+check_for_required_envs
+set_git_config
+
+if [ -n "$KERBEROS_PRINCIPAL" ]; then
+    get_kerb_ticket
+else
+    echo No kerberos principal specified, assuming there is a current kerberos ticket
+fi
+
+# load specific urls into the local cekit cache based on any files stored in
+# /opt/rhba/overrides/<branch> and an optional list in CEKIT_CACHE_LOCAL
+handle_cache_urls "$CEKIT_CACHE_LOCAL"
+
+generate_overrides_files
+get_extra_cekit_overrides_options $gen_overrides_dir
+
+debug=
+if [ -n "$DEBUG" ]; then
+    debug="-v"
+fi
+
+builduser=
+if [ -n "$OSBS_BUILD_USER" ]; then
+    builduser="--build-osbs-user=$OSBS_BUILD_USER"
+fi
+
+# Invoke cekit and respond with Y to any prompts
+echo cekit $debug --overrides-file branch-overrides.yaml $overrides $extraoverrides --build-engine=osbs --build-osbs-target=$OSBS_BUILD_TARGET $builduser --work-dir "$cekit_cache_dir" $CEKIT_BUILD_OPTIONS build
+
+yes Y | cekit $debug --overrides-file branch-overrides.yaml $overrides $extraoverrides --build-engine=osbs --build-osbs-target=$OSBS_BUILD_TARGET $builduser --work-dir "$cekit_cache_dir" $CEKIT_BUILD_OPTIONS build


### PR DESCRIPTION
[BXMSPROD-161] This is a script for use from jenkins for
running osbs image builds (the script can actually be
run from the commandline as well if build-overrides.sh
is on your path and you run it from an image directory).

Signed-off-by: Trevor McKay <tmckay@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
