### PR TITLE
[KIECLOUD-218] Logs are constantly flooded with 'Unable to load key store. Using password from configuration'

### DIFF
--- a/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-security.sh
+++ b/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-security.sh
@@ -216,8 +216,9 @@ print_user_information() {
 }
 
 ########## EAP ##########
-# If LDAP/SSO integration is enabled, do not create eap users.
+
 function add_eap_user() {
+    # If LDAP/SSO integration is enabled, do not create eap users.
      if [ "${AUTH_LDAP_URL}x" == "x" ] && [ "${SSO_URL}x" == "x" ]; then
         local kie_type="${1}"
         local eap_user="${2}"

--- a/tests/features/common/kie-workbench-common.feature
+++ b/tests/features/common/kie-workbench-common.feature
@@ -89,3 +89,9 @@ Feature: Decision/Business Central common features
      And container log should contain Make sure to configure a ADMIN user to access the Business Central with the roles kie-server,rest-all,admin,kiemgmt,Administrators
      And container log should contain Make sure to configure the KIE_MAVEN_USER user to interact with Business Central embedded maven server
      And container log should contain Make sure to configure the KIE_SERVER_CONTROLLER_USER user to interact with KIE Server rest api with the roles kie-server,rest-all,user
+
+  # https://issues.jboss.org/browse/KIECLOUD-218
+  # https://issues.jboss.org/browse/JBPM-8400
+  Scenario: Check for kie keystore
+    When container is ready
+    Then container log should contain -Dkie.keystore.keyStoreURL=file:///opt/eap/standalone/configuration/kie-kiestore.jceks


### PR DESCRIPTION
[KIECLOUD-218] Logs are constantly flooded with 'Unable to load key store. Using password from configuration'
https://issues.jboss.org/browse/KIECLOUD-218

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
