### PR TITLE
[KIECLOUD-225] - keeping permissions to old eap data-dir

### DIFF
--- a/jboss-kie-workbench/configure.sh
+++ b/jboss-kie-workbench/configure.sh
@@ -16,8 +16,12 @@ chown -R jboss:root ${JBOSS_HOME}/bin/
 chmod -R g+rwX ${JBOSS_HOME}/bin/
 
 # Ensure that the local data directory exists
-DATA_DIR=/opt/kie/data
+DATA_DIR=${JBOSS_HOME}/standalone/data
+KIE_HOME_DIR=/opt/kie
 mkdir -p ${DATA_DIR}
+mkdir -p ${KIE_HOME_DIR}
 # Necessary to permit running with a randomised UID
 chown -R jboss:root ${DATA_DIR}
 chmod -R 777 ${DATA_DIR}
+chown -R jboss:root ${KIE_HOME_DIR}
+chmod -R 777 ${KIE_HOME_DIR}


### PR DESCRIPTION
See: https://issues.jboss.org/browse/KIECLOUD-225
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
