### PR TITLE
[KIECLOUD-226] - Set RHPAM_NONXA to false on authoring templates

### DIFF
--- a/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
+++ b/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
@@ -5,6 +5,7 @@ mkdir -p $JBOSS_HOME/bin/launch
 
 cp $BATS_TEST_DIRNAME/../../../tests/bats/common/launch-common.sh $JBOSS_HOME/bin/launch
 cp $BATS_TEST_DIRNAME/../../../tests/bats/common/logging.bash $JBOSS_HOME/bin/launch/logging.sh
+cp $BATS_TEST_DIRNAME/../../../jboss-kie-common/added/launch/jboss-kie-common.sh $JBOSS_HOME/bin/launch/jboss-kie-common.sh
 cp $BATS_TEST_DIRNAME/../../../jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-security-login-modules.sh $JBOSS_HOME/bin/launch
 cp $BATS_TEST_DIRNAME/../../../jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-common.sh $JBOSS_HOME/bin/launch
 cp $BATS_TEST_DIRNAME/../../../jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-security.sh $JBOSS_HOME/bin/launch
@@ -24,10 +25,12 @@ teardown() {
   local expected_datasources="EJB_TIMER,RHPAM"
   export DATASOURCES="RHPAM"
   export RHPAM_XA_CONNECTION_PROPERTY_URL="jdbc:h2:/deployments/data/h2/rhpam;AUTO_SERVER=TRUE"
+  export RHPAM_NONXA="false"
   configure_EJB_Timer_datasource >&2
   echo "Expected EJB_TIMER url is ${EJB_TIMER_XA_CONNECTION_PROPERTY_URL}" >&2 
   echo "Expected DATASOURCES is ${DATASOURCES}" >&2 
   [ "${TIMER_SERVICE_DATA_STORE^^}" = "${expected_timer_service}" ]
   [ "${EJB_TIMER_XA_CONNECTION_PROPERTY_URL}" = "${RHPAM_XA_CONNECTION_PROPERTY_URL}" ]
   [ "${DATASOURCES}" = "${expected_datasources}" ]
+  [ "${RHPAM_NONXA}" = "false" ]
 }


### PR DESCRIPTION
Please see:
https://issues.jboss.org/browse/KIECLOUD-226

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
