### PR TITLE
[KIECLOUD-160] Adding http(s) support for git

### DIFF
--- a/jboss-kie-workbench/tests/bats/jboss-kie-workbench.bats
+++ b/jboss-kie-workbench/tests/bats/jboss-kie-workbench.bats
@@ -5,24 +5,25 @@ mkdir -p $JBOSS_HOME/bin/launch
 
 cp $BATS_TEST_DIRNAME/../../../tests/bats/common/launch-common.sh $JBOSS_HOME/bin/launch
 cp $BATS_TEST_DIRNAME/../../../tests/bats/common/logging.bash $JBOSS_HOME/bin/launch/logging.sh
+cp $BATS_TEST_DIRNAME/../../../jboss-kie-common/added/launch/jboss-kie-common.sh $JBOSS_HOME/bin/launch/jboss-kie-common.sh
 
 # begin mocks - import if require in future tests
 touch "${JBOSS_HOME}/bin/launch/login-modules-common.sh"
-touch "${JBOSS_HOME}/bin/launch/jboss-kie-common.sh"
+#touch "${JBOSS_HOME}/bin/launch/jboss-kie-common.sh"
 touch "${JBOSS_HOME}/bin/launch/jboss-kie-wildfly-common.sh"
 touch "${JBOSS_HOME}/bin/launch/management-common.sh"
 touch "${JBOSS_HOME}/bin/launch/logging.sh"
 touch "${JBOSS_HOME}/bin/launch/jboss-kie-wildfly-security.sh"
 
-function query_route_host() {
-  echo ""
+function query_default_route_host() {
+  echo "${WORKBENCH_ROUTE_NAME}-host"
+}
+
+function query_route_protocol() {
+  echo "http"
 }
 
 function query_route_service_host() {
-  echo ""
-}
-
-function build_route_url() {
   echo ""
 }
 # end mocks
@@ -41,4 +42,22 @@ teardown() {
 
     configure_guvnor_settings >&2
     [ -d "${GIT_HOOKS_DIR}" ]
+}
+
+@test "Check git http protocol was enabled successfully" {
+    WORKBENCH_ROUTE_NAME="businesscentral-route"
+    JBOSS_KIE_ARGS=""
+    local expected=$HOSTNAME
+    configure_guvnor_settings >&2
+    [[ $JBOSS_KIE_ARGS == *"-Dorg.uberfire.nio.git.http.enabled=true"* ]]
+    [[ $JBOSS_KIE_ARGS == *"-Dorg.uberfire.nio.git.http.hostname=${expected}"* ]]
+}
+
+@test "Check maven repo url has been correctly set" {
+    WORKBENCH_ROUTE_NAME="businesscentral-route"
+    JBOSS_KIE_ARGS=""
+    local expected="http://${HOSTNAME}:80/maven2"
+    echo "Expected is ${expected}" >&2
+    configure_guvnor_settings >&2
+    [[ $JBOSS_KIE_ARGS == *"-Dorg.appformer.m2repo.url=${expected}"* ]]
 }

--- a/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
+++ b/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
@@ -69,3 +69,13 @@ Feature: RHPAM Business Central configuration tests
   Scenario: Check Workbench profile for rhpam
     When container is ready
     Then container log should contain -Dorg.kie.workbench.profile=FORCE_FULL
+
+  # https://issues.jboss.org/browse/KIECLOUD-160
+  Scenario: Check Workbench for Git http support
+    When container is started with env
+      | variable         | value       |
+      | HOSTNAME_HTTP    | example.com |
+    Then container log should contain -Dorg.uberfire.nio.git.https.enabled=false
+     And container log should contain -Dorg.uberfire.nio.git.http.enabled=true
+     And container log should contain -Dorg.uberfire.nio.git.http.hostname=example.com
+     And container log should contain -Dorg.uberfire.nio.git.http.port=80


### PR DESCRIPTION
See: https://issues.jboss.org/browse/KIECLOUD-160

By using the default option of the env var `WORKBENCH_ROUTE_NAME`, which is the **non** secure route, the following properties were set to the busicess central:

```
org.uberfire.nio.git.daemon.enabled = false
org.uberfire.nio.git.dir = /opt/kie/data
org.uberfire.nio.git.http.enabled = true
org.uberfire.nio.git.http.hostname = bc-authoring-rhpamcentr-bsig-cloud.192.168.99.100.nip.io
org.uberfire.nio.git.http.port = 80
org.uberfire.nio.git.https.enabled = false
org.uberfire.nio.git.ssh.cert.dir = /opt/kie/data
org.uberfire.nio.git.ssh.enabled = false
```
Users will control which route should be used to enable the git over http. By doing that, I was able to interact with the git repo successfully:

```shell
$ git clone http://bc-authoring-rhpamcentr-bsig-cloud.192.168.99.100.nip.io:80/git/MySpace/example-Course_Scheduling
Cloning into 'example-Course_Scheduling'...
Username for 'http://bc-authoring-rhpamcentr-bsig-cloud.192.168.99.100.nip.io:80': adminuser
Password for 'http://adminuser@bc-authoring-rhpamcentr-bsig-cloud.192.168.99.100.nip.io:80': 
remote: Counting objects: 69, done
remote: Finding sources: 100% (69/69)
remote: Getting sizes: 100% (65/65)
remote: Compressing objects: 100% (69535/69535)
remote: Total 69 (delta 38), reused 0 (delta 0)
Unpacking objects: 100% (69/69), done.

$ git commit -am "test"

$ git push
Username for 'http://bc-authoring-rhpamcentr-bsig-cloud.192.168.99.100.nip.io:80': adminuser
Password for 'http://adminuser@bc-authoring-rhpamcentr-bsig-cloud.192.168.99.100.nip.io:80': 
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 8 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 286 bytes | 286.00 KiB/s, done.
Total 3 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2)
remote: Updating references: 100% (1/1)
To http://bc-authoring-rhpamcentr-bsig-cloud.192.168.99.100.nip.io:80/git/MySpace/example-Course_Scheduling
   37ffdd6..dd9dbc8  master -> master
```
The next steps are:

1) Updating the `WORKBENCH_ROUTE_NAME` variable description on templates and Operator
2) Add this var to APB
3) Updating the value of this var in the Operator to reflect the secure route that are being created there (today is referencing to a non-existing route)

Please let me know your thoughts.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
