### PR TITLE
[KIECLOUD-237] Removing the need of 'secure' prefix from secured routes

### DIFF
--- a/jboss-kie-common/tests/bats/jboss-kie-common.bats
+++ b/jboss-kie-common/tests/bats/jboss-kie-common.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+export JBOSS_HOME=$BATS_TMPDIR/jboss_home
+mkdir -p $JBOSS_HOME/bin/launch
+
+cp $BATS_TEST_DIRNAME/../../../tests/bats/common/launch-common.sh $JBOSS_HOME/bin/launch
+cp $BATS_TEST_DIRNAME/../../../tests/bats/common/logging.bash $JBOSS_HOME/bin/launch/logging.sh
+
+# imports
+source $BATS_TEST_DIRNAME/../../added/launch/jboss-kie-common.sh
+
+teardown() {
+    rm -rf $JBOSS_HOME
+}
+
+@test "check if route protocol returns its default value" {
+    local expected="http"
+    local result=$(query_route_protocol)
+    [ "${expected}" = "${result}" ]
+}
+
+@test "check if route protocol returns passed protocol" {
+    local expected="https"
+    local result=$(query_route_protocol "my-route" ${expected})
+    echo "Result is ${result} and expected is ${expected}" >&2
+    [ "${expected}" = "${result}" ]
+}
+
+@test "check if build_route_url creates a default url" {
+    local expected="https://${HOSTNAME}:443"
+    local result=$(build_route_url "my-route" "https" "${HOSTNAME}")
+    echo "Result is ${result} and expected is ${expected}" >&2
+    [ "${expected}" = "${result}" ]
+}
+
+@test "check if build_route_url does not create a secure url with port 80" {
+    local expected="https://${HOSTNAME}:443/"
+    local result=$(build_route_url "my-route" "https" "${HOSTNAME}" "80" "/")
+    echo "Result is ${result} and expected is ${expected}" >&2
+    [ "${expected}" = "${result}" ]
+}
+
+@test "check if build_route_url obey non standard secure port" {
+    local expected="https://${HOSTNAME}:8443/"
+    local result=$(build_route_url "my-route" "https" "${HOSTNAME}" "8443" "/")
+    echo "Result is ${result} and expected is ${expected}" >&2
+    [ "${expected}" = "${result}" ]
+}

--- a/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
+++ b/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
@@ -34,3 +34,20 @@ teardown() {
   [ "${DATASOURCES}" = "${expected_datasources}" ]
   [ "${RHPAM_NONXA}" = "false" ]
 }
+
+@test "check if kie server location is set according to the route" {
+  local expected="http://${HOSTNAME}:80/services/rest/server"
+  KIE_SERVER_ROUTE_NAME="my-route-name"
+  configure_server_location >&2
+  echo "JBOSS_KIE_ARGS is ${JBOSS_KIE_ARGS}" >&2
+  echo "Expected is ${expected}" >&2
+  [[ $JBOSS_KIE_ARGS == *"-Dorg.kie.server.location=${expected}"* ]]
+}
+
+@test "check if kie server location is set to default" {
+  local expected="http://${HOSTNAME}:8080/services/rest/server"
+  configure_server_location >&2
+  echo "JBOSS_KIE_ARGS is ${JBOSS_KIE_ARGS}" >&2
+  echo "Expected is ${expected}" >&2
+  [[ $JBOSS_KIE_ARGS == *"-Dorg.kie.server.location=${expected}"* ]]
+}


### PR DESCRIPTION
See: https://issues.jboss.org/browse/KIECLOUD-237

The idea of this PR is to **not** rely on the "secure" prefix used only on the Templates. This way we can actually query for the route properties and check if its protocol is a secure one or not.

The "sanity check" to verify if port is set to 80 when the route is secure, is to avoid use cases like this:

```
org.appformer.m2repo.url = https://secure-bc-authoring-rhpamcentr-bsig-cloud.192.168.99.100.nip.io:80/maven2
```

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
