### PR TITLE
[KIECLOUD-237] Fix query protocol problem (https)

### DIFF
--- a/jboss-kie-common/added/launch/jboss-kie-common.sh
+++ b/jboss-kie-common/added/launch/jboss-kie-common.sh
@@ -61,8 +61,7 @@ query_route_protocol() {
         local response=$(query_route "${routeName}")
         if [ "${response: -3}" = "200" ]; then
             # parse the json response to get the route host
-            local suffix=$(echo ${response::- 3} | python -c 'import json,sys;obj=json.load(sys.stdin); suffix = "s" if "tls" in obj["spec"] else "" ; print (suffix)')
-            protocol="${protocol}${suffix}"
+            local protocol=$(echo ${response::- 3} | python -c 'import json,sys;obj=json.load(sys.stdin); protocol = "https" if "tls" in obj["spec"] else "http" ; print (protocol)')
         else
             log_warning "Fail to query the Route using the Kubernetes API, the Service Account might not have the necessary privileges; defaulting to protocol [${protocol}]."
             if [ ! -z "${response}" ]; then

--- a/jboss-kie-common/tests/bats/jboss-kie-common.bats
+++ b/jboss-kie-common/tests/bats/jboss-kie-common.bats
@@ -9,6 +9,16 @@ cp $BATS_TEST_DIRNAME/../../../tests/bats/common/logging.bash $JBOSS_HOME/bin/la
 # imports
 source $BATS_TEST_DIRNAME/../../added/launch/jboss-kie-common.sh
 
+# mock function from jboss-kie-common.sh
+unset -f query_route
+
+function query_route() {
+    echo "Querying route" >&2
+    local response=$(cat $BATS_TEST_DIRNAME/mock_responses/single-route.json)
+    response="${response}200"
+    echo "${response}"
+}
+
 teardown() {
     rm -rf $JBOSS_HOME
 }
@@ -16,6 +26,7 @@ teardown() {
 @test "check if route protocol returns its default value" {
     local expected="http"
     local result=$(query_route_protocol)
+    echo "Result is ${result} and expected is ${expected}" >&2
     [ "${expected}" = "${result}" ]
 }
 
@@ -26,22 +37,30 @@ teardown() {
     [ "${expected}" = "${result}" ]
 }
 
+@test "check if route protocol queries the correct protocol" {
+    local expected="https"
+    # passing the wrong default protocol (mock will return https)
+    local result=$(query_route_protocol "my-route" "http")
+    echo "Result is ${result} and expected is ${expected}" >&2
+    [ "${expected}" = "${result}" ]
+}
+
 @test "check if build_route_url creates a default url" {
-    local expected="https://${HOSTNAME}:443"
+    local expected="https://myapp-my-namespace.com:443"
     local result=$(build_route_url "my-route" "https" "${HOSTNAME}")
     echo "Result is ${result} and expected is ${expected}" >&2
     [ "${expected}" = "${result}" ]
 }
 
 @test "check if build_route_url does not create a secure url with port 80" {
-    local expected="https://${HOSTNAME}:443/"
+    local expected="https://myapp-my-namespace.com:443/"
     local result=$(build_route_url "my-route" "https" "${HOSTNAME}" "80" "/")
     echo "Result is ${result} and expected is ${expected}" >&2
     [ "${expected}" = "${result}" ]
 }
 
 @test "check if build_route_url obey non standard secure port" {
-    local expected="https://${HOSTNAME}:8443/"
+    local expected="https://myapp-my-namespace.com:8443/"
     local result=$(build_route_url "my-route" "https" "${HOSTNAME}" "8443" "/")
     echo "Result is ${result} and expected is ${expected}" >&2
     [ "${expected}" = "${result}" ]

--- a/jboss-kie-common/tests/bats/mock_responses/single-route.json
+++ b/jboss-kie-common/tests/bats/mock_responses/single-route.json
@@ -1,0 +1,50 @@
+{
+    "metadata": {
+        "name": "my-route",
+        "namespace": "my-namespace",
+        "selfLink": "/apis/route.openshift.io/v1/namespaces/my-namespace/routes/my-route",
+        "uid": "eb9ed521-6d0a-11e9-8682-080027e8c7bc",
+        "resourceVersion": "1194535",
+        "creationTimestamp": "2019-05-02T18:48:48Z",
+        "labels": {
+            "app": "my-app",
+            "application": "my-app",
+            "template": "my-app",
+            "xpaas": "1.0.0"
+        },
+        "annotations": {
+            "description": "Route for application's https service.",
+            "openshift.io/generated-by": "OpenShiftNewApp",
+            "openshift.io/host.generated": "true"
+        }
+    },
+    "spec": {
+        "host": "myapp-my-namespace.com",
+        "to": {
+            "kind": "Service",
+            "name": "my-app",
+            "weight": 100
+        },
+        "tls": {
+            "termination": "edge",
+            "insecureEdgeTerminationPolicy": "Redirect"
+        },
+        "wildcardPolicy": "None"
+    },
+    "status": {
+        "ingress": [
+            {
+                "host": "myapp-my-namespace.com",
+                "routerName": "router",
+                "conditions": [
+                    {
+                        "type": "Admitted",
+                        "status": "True",
+                        "lastTransitionTime": "2019-05-02T18:48:48Z"
+                    }
+                ],
+                "wildcardPolicy": "None"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Fixing the error reported by @sutaakar:

```
[0m[33m10:59:39,826 WARN [org.kie.server.controller.impl.KieServerInstanceManager] (Thread-159) Unable to get list of containers from remote server at url httpss://secure-test-kieserver-ksuta-test.apps.rhba-ksuta.openshift-aws.rhocf-dev.com:443/services/rest/server due to org.kie.server.common.rest.NoEndpointFoundException: No available endpoints found
```
https://issues.jboss.org/browse/KIECLOUD-237

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
