### PR TITLE
[RHPAM-2008] HTTP 503 error is shown in Monitoring console when Kie sererver is scaled to 0

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver-hooks.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver-hooks.sh
@@ -56,8 +56,7 @@ if [ -n ${WORKBENCH_SERVICE_NAME} -a -n "${KIE_SERVER_ID}" ]; then
         fi
 
     elif [ ${kieReplicas} -gt 0 ]; then
-        log_info "KIE Server Replicas is ${kieReplicas}, updating ${KIE_SERVER_ID} configMap to USED."
-        update_config_map "{\"metadata\":{\"labels\":{\"services.server.kie.org/kie-server-state\":\"USED\"}}}" "${kieDCName}"
+        log_info "KIE Server Replicas is ${kieReplicas}"
 
         if [ "${controllerServiceHost}x" != "x" -a "${controllerServicePort}x" != "x" -a ${controllerReplicas} -gt 0  ]; then
             # curl command may be hanging a bit during dc pod starting up; need to update


### PR DESCRIPTION
The hook script is developed as a short term solution for this issue (https://issues.jboss.org/browse/RHPAM-2008?focusedCommentId=13736701&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13736701)

A side effect has been identified. It accidentally changes 'IMMUTABLE' label to 'USED'. Since there is an existing logic in java code to update CM label from 'DETACHED'. (https://github.com/kiegroup/droolsjbpm-integration/blob/c26b14377e62f02f5c8421cac7c51180a85bfaf6/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepository.java#L308-L315), the logic for updating CM from the hook script at 'postStart' section should be ignored, otherwise it must be updated with extra logic for changing label to either 'USED' or 'IMMUTABLE' based on similar condition at java code. 

@sutaakar @spolti 
The ideal sequence of events is (1) KIE Server started -> (2) Update label to either 'USED' or 'IMMUTABLE' -> (3) Notify BC/WB. 
Even though the 'postStart' hook is triggered before KIE Server get started, it is still **better than not notifying BC/WB**. After scale up from 0, the BC Process section may still show a Warning Page, but a browser refresh will bring the screen to correct display. For now, disabling update to CM label from 'postStart' logic could be the best we can have at the moment. 

Related JIRA
https://issues.jboss.org/projects/RHPAM/issues/RHPAM-2008

Related PRs
https://github.com/jboss-container-images/jboss-kie-modules/pull/251


Signed-off-by: Evan Zhang <evan.zhang@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
