### PR TITLE
[KIECLOUD-261] - Fixing port variable association

### DIFF
--- a/jboss-kie-smartrouter/added/launch/jboss-kie-smartrouter.sh
+++ b/jboss-kie-smartrouter/added/launch/jboss-kie-smartrouter.sh
@@ -92,7 +92,7 @@ function configure_router_location {
     fi
     JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.router.host=${host}"
     if [ "${port}" = "" ]; then
-        port==$(find_env "${controllerService}_SERVICE_PORT" "9000")
+        port=$(find_env "${controllerService}_SERVICE_PORT" "9000")
     fi
     JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.router.port=${port}"
     if [ -z "${routerUrlExternal}" ]; then


### PR DESCRIPTION
See: https://issues.jboss.org/browse/KIECLOUD-261

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
