### PR TITLE
[KIECLOUD-172] - Add behavior tests and correct check for execute per…

### DIFF
--- a/jboss-kie-kieserver/configure.sh
+++ b/jboss-kie-kieserver/configure.sh
@@ -35,7 +35,10 @@ chmod ug+x ${JBOSS_HOME}/bin/openshift-launch.sh
 
 # Set bin permissions
 chown -R jboss:root ${JBOSS_HOME}/bin/
-chmod -R g+rwx ${JBOSS_HOME}/bin/
+chmod -R g+rwX ${JBOSS_HOME}/bin/
+
+# Set exec permissions for scripts files in the launch dir
+chmod -R ug+x ${JBOSS_HOME}/bin/launch/*.sh
 
 # Ensure that the local KIE repository exists
 KIE_DIR=${HOME}/.kie

--- a/tests/features/rhpam/kieserver/rhpam-kieserver.feature
+++ b/tests/features/rhpam/kieserver/rhpam-kieserver.feature
@@ -917,3 +917,8 @@ Feature: RHPAM KIE Server configuration tests
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value h2 on XPath //*[local-name()='database-data-store']/@database
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ejb_timer-EJB_TIMER_part on XPath //*[local-name()='database-data-store']/@partition
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value -1 on XPath //*[local-name()='database-data-store']/@refresh-interval
+  
+  Scenario: Checks if the launch directory has the right permissions set
+    When container is ready
+    Then run sh -c '[ $(ls -l /opt/eap/bin/launch/*.sh | wc -l) -gt 0 ] && echo "has script files"' in container and check its output for has script files
+     And run sh -c 'exec=$(find -L /opt/eap/bin/launch -maxdepth 1 -type f -perm /u+x,g+x -name \*.sh | wc -l); nonexec=$(ls -l /opt/eap/bin/launch/*.sh | wc -l); [ $exec = $nonexec ] && echo "permissions ok"' in container and check its output for permissions ok


### PR DESCRIPTION
…missions

See:
https://issues.jboss.org/browse/KIECLOUD-172

After having some detailed analysis on the `chmod` command being executed, it's make sense leaving it that way, since won't change the execution permission on the files that don't need it.

Having said that, I added a small check in the `launch` directory and added the correct permissions to the script files only.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
