### PR TITLE
[RHPAM-1387] - Allow set Smart router location to external URL in RHPAM

### DIFF
--- a/jboss-kie-smartrouter/added/launch/jboss-kie-smartrouter.sh
+++ b/jboss-kie-smartrouter/added/launch/jboss-kie-smartrouter.sh
@@ -100,7 +100,7 @@ function configure_router_location {
     if [ -z "${routerUrlExternal}" ]; then
        if [ -n "${routeName}" ]; then
             if [ "${protocol}" = "https" ]; then
-                routeName="secure-${routeName}"
+                routeName="${routeName}"
                 host="${host:-${defaultSecureHost}}"
                 port="${port:-443}"
             else
@@ -115,11 +115,11 @@ function configure_router_location {
        else
             if [ "${protocol}" = "https" ]; then
                 host="${host:-${defaultSecureHost}}"
-                port="${port:-9443}"
+                port="${KIE_SERVER_ROUTER_PORT_TLS:-9443}"
             else
                 protocol="${protocol:-http}"
                 host="${host:-${defaultInsecureHost}}"
-                port="${port:-9000}"
+                port="${KIE_SERVER_ROUTER_PORT:-9000}"
             fi
             routerUrlExternal=$(build_simple_url "${protocol}" "${host}" "${port}")
         fi


### PR DESCRIPTION
align secure route and ROUTER_PORT envs.
does not hardcode the secure route, on apb and operator there is no
such prefix.

Signed-off-by: Filippe Spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
