### PR TITLE
[RHPAM-2310] Add jboss-kie-module for process migration service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,3 +37,7 @@ jobs:
           name: Run jboss-kie-workbench bats tests
           command: |
             $HOME/bin/bats jboss-kie-workbench/tests/bats/
+      - run:
+          name: Run jboss-kie-process-migration bats tests
+          command: |
+            $HOME/bin/bats jboss-kie-process-migration/tests/bats/

--- a/jboss-kie-process-migration/added/configuration/application-roles.properties
+++ b/jboss-kie-process-migration/added/configuration/application-roles.properties
@@ -1,0 +1,1 @@
+%USER%=admin

--- a/jboss-kie-process-migration/added/configuration/application-users.properties
+++ b/jboss-kie-process-migration/added/configuration/application-users.properties
@@ -1,0 +1,1 @@
+%USER%=%PASSWORD%

--- a/jboss-kie-process-migration/added/configuration/project-cloud.yml
+++ b/jboss-kie-process-migration/added/configuration/project-cloud.yml
@@ -1,0 +1,12 @@
+thorntail:
+  security:
+    security-domains:
+      pim:
+        classic-authentication:
+          login-modules:
+            UsersRoles:
+              code: UsersRoles
+              flag: required
+              module-options:
+                usersProperties: /opt/rhpam-process-migration/config/application-users.properties
+                rolesProperties: /opt/rhpam-process-migration/config/application-roles.properties

--- a/jboss-kie-process-migration/added/launch/configure.sh
+++ b/jboss-kie-process-migration/added/launch/configure.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+
+# This script executes a list of modules defined by CONFIGURE_SCRIPTS.
+#
+# Configuration occurs over three basic phases: preConfigure, configure and
+# postConfigure.
+#
+# The configure phase is special in that it iterates over a series of
+# environments.  In addition to the execution environment, users may specify
+# additional configuration details through environment scripts specified through
+# the ENV_FILES variable.  The processing of env files is similar to the process
+# for the execution environment, with the addition of a prepareEnv method, which
+# is used to clean the environment before processing the env contributed by
+# a file.  This is to help ensure that duplicate configurations are not created
+# when processing env files.
+#
+# The following details the API which the modules may implement.  If a
+# particular function is not implemented by a module, it is treated as a no-op.
+#
+# preConfigure:     invoked before any configuration takes place.  Use this to
+#                   manipulate the environment prior to configuration.  For
+#                   example, the backward-compatiblity.sh module initializes
+#                   environment variables from older variable names, if present.
+#
+# configure:        invoked to configure based on the execution environment.
+#
+# postConfigure:    invoked after all configuration has been completed.
+#
+# prepareEnv:       invoked prior to processing env files.  Modules should
+#                   use this to prepare the environment before processing
+#                   configuration from a file, e.g. by unset'ing variables
+#                   defined in the execution environment to prevent duplicate
+#                   configuration entries.  This method is invoked once, as
+#                   each env file is processed in a subshell, thus preventing
+#                   contamination of the environment from file to file.
+#
+# preConfigureEnv:  similar to preConfigure, except this is invoked after an env
+#                   file has been sourced, but before configureEnv.
+#
+# configureEnv:     similar to configure.
+#
+# postConfigureEnv: simliar to postConfigure, except that it is invoked for each
+#                   env file.
+#
+# The reason the configuration API is duplicated for an Env, is that some
+# modules may not support env files, or may require configuration of "singleton"
+# type entries, which should only be processed once.
+#
+
+source ${LAUNCH_DIR}/logging.sh
+
+# clear functions from any previous module
+function prepareModule() {
+  unset -f preConfigure
+  unset -f configure
+  unset -f postConfigure
+
+  unset -f prepareEnv
+  unset -f preConfigureEnv
+  unset -f configureEnv
+  unset -f postConfigureEnv
+}
+
+# Execute a particular function from a module
+# $1 - module file
+# $2 - function name
+function executeModule() {
+  source $1;
+  if [ -n "$(type -t $2)" ]; then
+    eval $2
+  fi
+}
+
+# Run through the list of scripts, executing the specified function for each.
+# $1 - function name
+function executeModules() {
+  for module in ${CONFIGURE_SCRIPTS[@]}; do
+    prepareModule
+    executeModule $module $1
+  done
+}
+
+# Processes the files provided by ENV_FILES.  Invokes the *Env functions for
+# each module.  Env processing is done in subshells.  The outer subshell
+# provides a sanitized environment, that will be used by each inner subshell.
+# This insulates the execution environment from any changes made during env
+# file processing, and keeps the base environment the same from file to file
+# (i.e. we don't have to run prepareEnv for each file).
+function processEnvFiles() {
+  if [ -n "$ENV_FILES" ]; then
+    (
+      executeModules prepareEnv
+      for prop_file_arg in $(echo $ENV_FILES | sed "s/,/ /g"); do
+        for prop_file in $(find $prop_file_arg -maxdepth 0 2>/dev/null); do
+          (
+            if [ -f $prop_file ]; then
+              source $prop_file
+              executeModules preConfigureEnv
+              executeModules configureEnv
+              executeModules postConfigureEnv
+            else
+              log_warning "Could not process environment for $prop_file.  File does not exist."
+            fi
+          )
+        done
+      done
+    )
+  fi
+}
+
+executeModules preConfigure
+executeModules configure
+processEnvFiles
+executeModules postConfigure

--- a/jboss-kie-process-migration/added/launch/jboss-kie-process-migration.sh
+++ b/jboss-kie-process-migration/added/launch/jboss-kie-process-migration.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+source "${LAUNCH_DIR}/launch-common.sh"
+source "${LAUNCH_DIR}/logging.sh"
+source "${JBOSS_HOME}/bin/launch/jboss-kie-common.sh"
+
+function prepareEnv() {
+    # please keep these in alphabetical order
+    JBOSS_KIE_ADMIN_USER
+    JBOSS_KIE_ADMIN_PWD
+    JBOSS_KIE_EXTRA_CLASSPATH
+    JBOSS_KIE_EXTRA_CONFIG
+}
+
+function configureEnv() {
+    configure
+}
+
+function configure() {
+    configure_extra_classpath
+    configure_extra_config
+    configure_users
+}
+
+function trim() {
+    local var="$*"
+    # remove leading whitespace characters
+    var="${var##*( )}"
+    # remove trailing whitespace characters
+    var="${var%%*( )}"
+    echo -n "$var"
+}
+
+# Comma separated list of libraries to add to the classpath
+function configure_extra_classpath() {
+    local classpath
+    if [[ -n ${JBOSS_KIE_EXTRA_CLASSPATH} ]]; then
+        IFS=',' read -ra entries <<< "${JBOSS_KIE_EXTRA_CLASSPATH}"
+        for entry in "${entries[@]}"
+        do
+            if [[ -z ${classpath} ]]; then
+                classpath="-Dthorntail.classpath=`trim ${entry}`"
+            else
+                classpath="${classpath} -Dthorntail.classpath=`trim ${entry}`"
+            fi
+        done
+    fi
+    JBOSS_KIE_EXTRA_CLASSPATH=${classpath}
+}
+
+function configure_extra_config() {
+    if [[ -n ${JBOSS_KIE_EXTRA_CONFIG} ]]; then
+        JBOSS_KIE_EXTRA_CONFIG="-s${JBOSS_KIE_EXTRA_CONFIG}"
+    else
+        JBOSS_KIE_EXTRA_CONFIG=""
+    fi
+}
+
+function configure_users() {
+    local user=${JBOSS_KIE_ADMIN_USER:-admin}
+    local pwd=${JBOSS_KIE_ADMIN_PWD:-`< /dev/urandom tr -dc A-Za-z0-9\!_ | head -c8`}
+    sed -i -e "s;%USER%;$user;g" -e "s;%PASSWORD%;$pwd;g" ${CONFIG_DIR}/application-users.properties
+    sed -i -e "s;%USER%;$user;g" ${CONFIG_DIR}/application-roles.properties
+}

--- a/jboss-kie-process-migration/added/launch/launch-common.sh
+++ b/jboss-kie-process-migration/added/launch/launch-common.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# common subroutines used in various places of the launch scripts
+
+# Finds the environment variable  and returns its value if found.
+# Otherwise returns the default value if provided.
+#
+# Arguments:
+# $1 env variable name to check
+# $2 default value if environment variable was not set
+function find_env() {
+  var=${!1}
+  echo "${var:-$2}"
+}
+

--- a/jboss-kie-process-migration/added/openshift-launch.sh
+++ b/jboss-kie-process-migration/added/openshift-launch.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Openshift JBoss KIE - Process migration launch script
+
+source ${LAUNCH_DIR}/logging.sh
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    SHOW_JVM_SETTINGS="-XshowSettings:properties"
+    log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+    log_info "JVM settings debug is enabled."
+fi
+
+CONFIGURE_SCRIPTS=(
+  ${LAUNCH_DIR}/jboss-kie-process-migration.sh
+)
+
+source ${LAUNCH_DIR}/configure.sh
+source /usr/local/dynamic-resources/dynamic_resources.sh
+
+log_info "Running $JBOSS_IMAGE_NAME image, version $PRODUCT_VERSION"
+
+if [ -n "$CLI_GRACEFUL_SHUTDOWN" ] ; then
+  trap "" TERM
+  log_info "Using CLI Graceful Shutdown instead of TERM signal"
+fi
+
+
+# RHPAM-1135: We need to build and pass an array otherwise spaces in passwords will break the exec
+D_OPTS="${JBOSS_KIE_ARGS}"
+D_DLM=" -D"
+D_STR=" ${D_OPTS}${D_DLM}"
+D_ARR=()
+while [[ $D_STR ]]; do
+    D_TMP="${D_STR%%"$D_DLM"*}"
+    if [[ ! "${D_TMP}" =~ ^\ +$ ]] && [[ "x${D_TMP}" != "x" ]]; then
+        D_TMP=$(eval "echo \"${D_TMP}\"")
+        D_ARR+=("-D${D_TMP}")
+    fi
+    D_STR=${D_STR#*"$D_DLM"}
+done
+
+exec ${JAVA_HOME}/bin/java ${SHOW_JVM_SETTINGS} "${D_ARR[@]}" ${JBOSS_KIE_EXTRA_CLASSPATH} -jar /opt/${JBOSS_PRODUCT}/${KIE_PROCESS_MIGRATION_DISTRIBUTION_JAR} -s${CONFIG_DIR}/project-cloud.yml ${JBOSS_KIE_EXTRA_CONFIG}

--- a/jboss-kie-process-migration/configure.sh
+++ b/jboss-kie-process-migration/configure.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Openshift JBoss KIE - Process migration launch script and helpers
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+PROCESS_MIGRATION_DIR=/opt/${JBOSS_PRODUCT}
+
+# Add custom launch script and dependent scripts/libraries/snippets
+cp -p ${ADDED_DIR}/openshift-launch.sh ${PROCESS_MIGRATION_DIR}/
+
+mkdir -p ${LAUNCH_DIR}
+cp -r ${ADDED_DIR}/launch/* ${LAUNCH_DIR}
+
+mkdir -p ${CONFIG_DIR}
+cp -r ${ADDED_DIR}/configuration/* ${CONFIG_DIR}
+
+# Necessary to permit running with a randomised UID
+chown -R jboss:root ${PROCESS_MIGRATION_DIR}
+chmod -R 777 ${PROCESS_MIGRATION_DIR}

--- a/jboss-kie-process-migration/module.yaml
+++ b/jboss-kie-process-migration/module.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+name: jboss-kie-process-migration
+version: '1.0'
+description: The jboss-kie-process-migration module.
+execute:
+    - script: configure.sh

--- a/jboss-kie-process-migration/tests/bats/jboss-kie-process-migration.bats
+++ b/jboss-kie-process-migration/tests/bats/jboss-kie-process-migration.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+
+export JBOSS_HOME=$BATS_TMPDIR/jboss_home
+export LAUNCH_DIR=$JBOSS_HOME/bin/launch
+export CONFIG_DIR=$JBOSS_HOME/configuration
+mkdir -p $LAUNCH_DIR
+
+cp $BATS_TEST_DIRNAME/../../../tests/bats/common/launch-common.sh $JBOSS_HOME/bin/launch
+cp $BATS_TEST_DIRNAME/../../../tests/bats/common/logging.bash $JBOSS_HOME/bin/launch/logging.sh
+cp $BATS_TEST_DIRNAME/../../../jboss-kie-common/added/launch/jboss-kie-common.sh $JBOSS_HOME/bin/launch/jboss-kie-common.sh
+
+#imports
+source $BATS_TEST_DIRNAME/../../added/launch/jboss-kie-process-migration.sh
+
+setup() {
+  cp -r $BATS_TEST_DIRNAME/../../added/configuration $JBOSS_HOME/configuration
+}
+
+teardown() {
+    rm -rf $JBOSS_HOME
+}
+
+@test "check if extra classpath is set correctly" {
+  local expected
+
+  JBOSS_KIE_EXTRA_CLASSPATH="mysql-driver.jar"
+  expected="-Dthorntail.classpath=mysql-driver.jar"
+  configure_extra_classpath >&2
+  echo "JBOSS_KIE_EXTRA_CLASSPATH is ${JBOSS_KIE_EXTRA_CLASSPATH}" >&2
+  echo "Expected is ${expected}" >&2
+  [[ $JBOSS_KIE_EXTRA_CLASSPATH == "${expected}" ]]
+}
+
+@test "check if extra classpath is set correctly for multiple entries" {
+  local expected
+
+  JBOSS_KIE_EXTRA_CLASSPATH="mysql-driver.jar, oracledb-driver.jar"
+  expected="-Dthorntail.classpath=mysql-driver.jar -Dthorntail.classpath=oracledb-driver.jar"
+  configure_extra_classpath >&2
+  echo "JBOSS_KIE_EXTRA_CLASSPATH is ${JBOSS_KIE_EXTRA_CLASSPATH}" >&2
+  echo "Expected is ${expected}" >&2
+  [[ $JBOSS_KIE_EXTRA_CLASSPATH == "${expected}" ]]
+}
+
+@test "check if extra classpath is empty when defined but empty" {
+  local expected
+
+  JBOSS_KIE_EXTRA_CLASSPATH=""
+  expected=""
+  configure_extra_classpath >&2
+  echo "JBOSS_KIE_EXTRA_CLASSPATH is ${JBOSS_KIE_EXTRA_CLASSPATH}" >&2
+  echo "Expected is ${expected}" >&2
+  [[ $JBOSS_KIE_EXTRA_CLASSPATH == "${expected}" ]]
+}
+
+@test "check if extra classpath is empty when undefined" {
+  local expected
+
+  [[ -z $JBOSS_KIE_EXTRA_CLASSPATH ]]
+  expected=""
+  configure_extra_classpath >&2
+  echo "JBOSS_KIE_EXTRA_CLASSPATH is ${JBOSS_KIE_EXTRA_CLASSPATH}" >&2
+  echo "Expected is ${expected}" >&2
+  [[ $JBOSS_KIE_EXTRA_CLASSPATH == "${expected}" ]]
+}
+
+@test "check if extra config is empty when undefined" {
+  local expected
+
+  [[ -z $JBOSS_KIE_EXTRA_CONFIG ]]
+  expected=""
+  configure_extra_classpath >&2
+  echo "JBOSS_KIE_EXTRA_CONFIG is ${JBOSS_KIE_EXTRA_CONFIG}" >&2
+  echo "Expected is ${expected}" >&2
+  [[ $JBOSS_KIE_EXTRA_CONFIG == "${expected}" ]]
+}
+
+@test "check if extra config is empty when defined but empty" {
+  local expected
+
+  JBOSS_KIE_EXTRA_CONFIG=""
+  expected=""
+  configure_extra_classpath >&2
+  echo "JBOSS_KIE_EXTRA_CONFIG is ${JBOSS_KIE_EXTRA_CONFIG}" >&2
+  echo "Expected is ${expected}" >&2
+  [[ $JBOSS_KIE_EXTRA_CONFIG == "${expected}" ]]
+}
+
+@test "check if extra config is set" {
+  local expected
+
+  JBOSS_KIE_EXTRA_CONFIG="./config-extra/configuration.yml"
+  expected="-s./config-extra/configuration.yml"
+  configure_extra_config >&2
+  echo "JBOSS_KIE_EXTRA_CONFIG is ${JBOSS_KIE_EXTRA_CONFIG}" >&2
+  echo "Expected is ${expected}" >&2
+  [[ $JBOSS_KIE_EXTRA_CONFIG == "${expected}" ]]
+}
+
+@test "check if roles file is populated with default values" {
+  configure_users
+  local roles=$(head -n 1 $CONFIG_DIR/application-roles.properties)
+  expected="admin=admin"
+  echo "roles first line is ${roles}"
+  echo "Expected is ${expected}" >&2
+  [[ ${roles} == "${expected}" ]]
+}
+
+@test "check if roles file is populated with provided values" {
+  JBOSS_KIE_ADMIN_USER=foo
+  configure_users
+  local roles=$(head -n 1 $CONFIG_DIR/application-roles.properties)
+  expected="foo=admin"
+  echo "roles first line is ${roles}"
+  echo "Expected is ${expected}" >&2
+  [[ ${roles} == "${expected}" ]]
+}
+
+@test "check if users file is populated with default values" {
+  configure_users
+  local users=$(head -n 1 $CONFIG_DIR/application-users.properties)
+  expected="^admin=[a-zA-Z0-9_\!]{8}$"
+  echo "users first line is ${users}"
+  echo "Expected is ${expected}" >&2
+  [[ ${users} =~ ${expected} ]]
+}
+
+@test "check if users file is populated with provided values" {
+  JBOSS_KIE_ADMIN_USER=foo
+  JBOSS_KIE_ADMIN_PWD=test
+  configure_users
+  local users=$(head -n 1 $CONFIG_DIR/application-users.properties)
+  expected="foo=test"
+  echo "users first line is ${users}"
+  echo "Expected is ${expected}" >&2
+  [[ ${users} == "${expected}" ]]
+}


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fix https://issues.jboss.org/browse/RHPAM-2310

Adds jboss-kie-module for process migration service including scripts and default configurations to be used in the resulting image.

Allows configuring extra classpath entries (that would be provided inside the image) and additional configuration file to override defaults.