### PR TITLE
[KIECLOUD-304] - MAVEN_SETTINGS_XML is not honored by jboss-kie-modul…

### DIFF
--- a/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-common.sh
+++ b/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-common.sh
@@ -28,8 +28,8 @@ function configure_maven_settings() {
     local mavenSettings="${HOME}/.m2/settings.xml"
     # maven module already takes care if the provided file exist, if a non existent file or directory is set
     # it will automatically fallback to the default settings.xml
-    if [ ! -z "${MAVEN_SETTINGS_XML}" ]; then
-        log_info "Custom maven settings provided, validating ${MAVEN_SETTINGS_XML}, if this file is not the value that was set, probably the value set points to a non existent file or directory. Enable debug for details."
+    if [ ! -z "${MAVEN_SETTINGS_XML}" -a "${MAVEN_SETTINGS_XML}" != "${mavenSettings}" ]; then
+        log_info "Custom maven settings provided, validating ${MAVEN_SETTINGS_XML}."
         validationResult=$(mvn help:effective-settings -s "${MAVEN_SETTINGS_XML}")
         if [ $? -eq 0 ]; then
             mavenSettings="${MAVEN_SETTINGS_XML}"


### PR DESCRIPTION
…es scripts

add a little tweak to only validate the settings.xml if the content of the
MAVEN_SETTINGS_XML is different than the default.

Signed-off-by: Filippe Spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
