### PR TITLE
[KIECLOUD-246] Business / Decision Central missing required RH-SSO configuration

### DIFF
--- a/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-security.sh
+++ b/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-security.sh
@@ -267,7 +267,7 @@ function set_application_roles_config() {
 
 function add_eap_user() {
     # If LDAP/SSO integration is enabled, do not create eap users.
-     if [ "${AUTH_LDAP_URL}x" == "x" ] && [ "${SSO_URL}x" == "x" ]; then
+    if [ "${AUTH_LDAP_URL}x" == "x" ] && [ "${SSO_URL}x" == "x" ]; then
         local kie_type="${1}"
         local eap_user="${2}"
         local eap_pwd="${3}"
@@ -280,15 +280,15 @@ function add_eap_user() {
         else
             local add_user_args=(
                 "-a"
-                "--user" "${eap_user}"
-                "--password" "${eap_pwd}"
+                "--user" "'${eap_user}'"
+                "--password" "'${eap_pwd}'"
             )
-            add_user_args+=( "--user-properties" "${application_users_properties}" )
-            add_user_args+=( "--group-properties" "${application_roles_properties}" )
+            add_user_args+=( "--user-properties" "'${application_users_properties}'" )
+            add_user_args+=( "--group-properties" "'${application_roles_properties}'" )
             if [ "x${eap_roles}" != "x" ]; then
                 add_user_args+=( "--role" "${eap_roles}" )
             fi
-            ${JBOSS_HOME}/bin/add-user.sh ${add_user_args[@]}
+            eval "${JBOSS_HOME}/bin/add-user.sh ${add_user_args[@]}"
             if [ "$?" -ne "0" ]; then
                 log_error "Failed to add KIE ${kie_type} user \"${eap_user}\" in EAP"
                 log_error "Exiting..."

--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -254,6 +254,16 @@ function configure_guvnor_settings() {
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.uberfire.nio.git.https.enabled=false"
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.uberfire.nio.git.http.enabled=false"
     fi
+    # User management service (KIECLOUD-246, AF-2083, AF-2086)
+    if [ -n "${SSO_URL}" ]; then
+        # https://github.com/kiegroup/appformer/tree/master/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.uberfire.ext.security.management.api.userManagementServices=KCAdapterUserManagementService"
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.uberfire.ext.security.management.keycloak.authServer=${SSO_URL}"
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.jbpm.workbench.kie_server.keycloak=true"
+    else
+        # https://github.com/kiegroup/appformer/tree/master/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.uberfire.ext.security.management.api.userManagementServices=WildflyCLIUserManagementService"
+    fi
 }
 
 # Set the max metaspace size only for the workbench

--- a/tests/features/common/kie-workbench-common.feature
+++ b/tests/features/common/kie-workbench-common.feature
@@ -23,6 +23,9 @@ Feature: Decision/Business Central common features
      And file /opt/eap/standalone/configuration/application-roles.properties should contain customCtl=role2
      And file /opt/eap/standalone/configuration/application-users.properties should not contain customExe=d2d5d854411231a97fdbf7fe6f91a786
      And file /opt/eap/standalone/configuration/application-roles.properties should not contain customExe=kie-server,rest-all,user
+     And container log should contain -Dorg.uberfire.ext.security.management.api.userManagementServices=WildflyCLIUserManagementService
+     And container log should not contain -Dorg.uberfire.ext.security.management.keycloak.authServer
+     And container log should not contain -Dorg.jbpm.workbench.kie_server.keycloak
 
   Scenario: Check if eap users are not being created if SSO is configured
     When container is started with env
@@ -48,6 +51,9 @@ Feature: Decision/Business Central common features
      And container log should contain KIE_ADMIN_USER is set to customAdm, make sure to configure this user with the provided password on the external auth provider with the roles role1,admin2
      And container log should contain KIE_MAVEN_USER is set to customMvn, make sure to configure this user with the provided password on the external auth provider.
      And container log should contain KIE_SERVER_CONTROLLER_USER is set to customCtl, make sure to configure this user with the provided password on the external auth provider with the roles role2
+     And container log should contain -Dorg.uberfire.ext.security.management.api.userManagementServices=KCAdapterUserManagementService
+     And container log should contain -Dorg.uberfire.ext.security.management.keycloak.authServer=http://url
+     And container log should contain -Dorg.jbpm.workbench.kie_server.keycloak=true
 
   Scenario: Check if eap users are not being created if LDAP is configured
     When container is started with env
@@ -94,4 +100,4 @@ Feature: Decision/Business Central common features
   # https://issues.jboss.org/browse/JBPM-8400
   Scenario: Check for kie keystore
     When container is ready
-    Then container log should contain -Dkie.keystore.keyStoreURL=file:///opt/eap/standalone/configuration/kie-kiestore.jceks
+    Then container log should contain -Dkie.keystore.keyStoreURL=file:///opt/eap/standalone/configuration/kie-keystore.jceks


### PR DESCRIPTION
[KIECLOUD-246] Business / Decision Central missing required RH-SSO configuration
https://issues.jboss.org/browse/KIECLOUD-246

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
