### PR TITLE
[RHDM-1096] - Add missing environment variable for optaplanner

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -42,6 +42,7 @@ function prepareEnv() {
     unset KIE_SERVER_SYNC_DEPLOY
     unset MYSQL_ENABLED_TLS_PROTOCOLS
     unset PROMETHEUS_SERVER_EXT_DISABLED
+    unset OPTAPLANNER_SERVER_EXT_THREAD_POOL_QUEUE_SIZE
 }
 
 function preConfigure() {
@@ -66,6 +67,7 @@ function configure() {
     configure_kie_server_mgmt
     configure_mode
     configure_prometheus
+    configure_optaplanner
     # configure_server_state always has to be last
     configure_server_state
 }
@@ -584,6 +586,12 @@ function configure_jbpm() {
         fi
     elif [ "${JBOSS_PRODUCT}" = "rhdm-kieserver" ]; then
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.jbpm.server.ext.disabled=true -Dorg.jbpm.ui.server.ext.disabled=true -Dorg.jbpm.case.server.ext.disabled=true"
+    fi
+}
+
+function configure_optaplanner() {
+    if [ -n "${OPTAPLANNER_SERVER_EXT_THREAD_POOL_QUEUE_SIZE}" ]; then
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.optaplanner.server.ext.thread.pool.queue.size=${OPTAPLANNER_SERVER_EXT_THREAD_POOL_QUEUE_SIZE}"
     fi
 }
 

--- a/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
+++ b/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
@@ -332,3 +332,12 @@ teardown() {
         [ "${create_table_default}" = "${create_table_mssql}" ]
     done
 }
+
+@test "Check if the optaplanner thread pool queue size is set" {
+    export OPTAPLANNER_SERVER_EXT_THREAD_POOL_QUEUE_SIZE="4"
+    local expected="4"
+    configure_optaplanner >&2
+    echo "Result: ${JBOSS_KIE_ARGS}"
+    echo "Expected: ${expected}"
+    [[ $JBOSS_KIE_ARGS == *"-Dorg.optaplanner.server.ext.thread.pool.queue.size=${expected}"* ]]
+}

--- a/tests/features/common/kie-kieserver-common.feature
+++ b/tests/features/common/kie-kieserver-common.feature
@@ -458,3 +458,14 @@ Feature: Kie Server common features
       | MQ_SERVICE_PREFIX_MAPPING | AMQPREFIX |
     Then container log should contain Configuring external JMS integration, removing /opt/eap/standalone/deployments/ROOT.war/META-INF/kie-server-jms.xml
      And file /opt/eap/standalone/deployments/ROOT.war/META-INF/kie-server-jms.xml should not exist
+
+  Scenario: RHDM-1096 - Check that optaplanner thread pool queue size property is not set without env.
+    When container is started with env
+      | variable        | value  |
+    Then container log should not contain -Dorg.optaplanner.server.ext.thread.pool.queue.size=
+
+  Scenario: RHDM-1096 - Check that optaplanner thread pool queue size property is set
+    When container is started with env
+      | variable        | value      |
+      | OPTAPLANNER_SERVER_EXT_THREAD_POOL_QUEUE_SIZE | 4 |
+    Then container log should contain -Dorg.optaplanner.server.ext.thread.pool.queue.size=4


### PR DESCRIPTION
Add missing environment variable for optaplanner thread pool queue size

See: https://issues.jboss.org/browse/RHDM-1096

Signed-off-by: Mauricio Magnani <mmagnani@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
