### PR TITLE
[RHPAM-2175] Add admin role to controller and execution users

### DIFF
--- a/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-security.sh
+++ b/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-security.sh
@@ -119,7 +119,7 @@ function get_kie_server_token() {
 }
 
 function get_kie_server_roles() {
-    local default_kie_roles="kie-server,rest-all,user"
+    local default_kie_roles="kie-server,rest-all,user,admin"
     echo $(find_env "KIE_SERVER_ROLES" "${default_kie_roles}")
 }
 
@@ -163,7 +163,7 @@ function get_kie_server_controller_token() {
 }
 
 function get_kie_server_controller_roles() {
-    local default_kie_roles="kie-server,rest-all,user"
+    local default_kie_roles="kie-server,rest-all,user,admin"
     echo $(find_env "KIE_SERVER_CONTROLLER_ROLES" "${default_kie_roles}")
 }
 


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fix https://issues.jboss.org/browse/RHPAM-2175

@errantepiphany @spolti @rhtevan Instead of removing controller/execution users it might be better to grant admin roles to both internal users.
Let me know what do you think.