### PR TITLE
[RHPAM-2634] Remote Server is lot from the controller after Kie Server scale down and scale up

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver-hooks.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver-hooks.sh
@@ -9,6 +9,36 @@ controllerServiceName=${WORKBENCH_SERVICE_NAME//-/_}
 controllerServiceHost=$(find_env "${controllerServiceName^^}_SERVICE_HOST")
 controllerServicePort=$(find_env "${controllerServiceName^^}_SERVICE_PORT_HTTP")
 
+# KIE Server default state when scaled down to 0 
+state="DETACHED"
+kieCMName=""
+
+check_kieserver_state() {
+    local uri="configmaps?labelSelector=services.server.kie.org%2Fkie-server-id%3D${KIE_SERVER_ID}"
+    local resp=$(query_ocp_api "api" "${uri}")
+    state=$(echo ${resp:: -3} | python -c 'import json,sys;obj=json.load(sys.stdin);print (obj["items"][0]["metadata"]["labels"]["services.server.kie.org/kie-server-state"])' 2>/dev/null)
+    kieCMName=$(echo ${resp:: -3} | python -c 'import json,sys;obj=json.load(sys.stdin);print (obj["items"][0]["metadata"]["name"])' 2>/dev/null)
+    if [[ -z "$state" ]]; then
+        state="DETACHED"
+    fi
+}
+
+# param
+# ${1} - when scale up or down
+check_state_loop() {
+    local scaleUporDown=${1}
+    for ((i = 0; i < 15; i++)); do
+        check_kieserver_state
+        if [[ "$scaleUporDown" == "up" ]] && [[ "$state" != "DETACHED" ]]; then
+            break;
+        fi
+        if [[ "$scaleUporDown" == "down" ]] && [[ "$state" == "DETACHED" ]]; then
+            break;
+        fi
+        sleep 3
+    done
+}
+
 # param
 # ${1} - the config map payload
 # ${2} - ConfigMap name
@@ -29,21 +59,30 @@ update_config_map() {
 }
 
 if [ -n ${WORKBENCH_SERVICE_NAME} -a -n "${KIE_SERVER_ID}" ]; then
-
+    check_kieserver_state
     kieServeruri="deploymentconfigs?labelSelector=services.server.kie.org%2Fkie-server-id%3D${KIE_SERVER_ID}"
     kieResponse=$(query_ocp_api "apis/apps.openshift.io" "${kieServeruri}")
     kieReplicas=$(echo ${kieResponse:: -3} | python -c 'import json,sys;obj=json.load(sys.stdin);print (obj["items"][0]["spec"]["replicas"])')
     kieDCName=$(echo ${kieResponse:: -3} | python -c 'import json,sys;obj=json.load(sys.stdin);print (obj["items"][0]["metadata"]["name"])')
+    if [[ -z "$kieReplicas" ]]; then
+        kieReplicas=0
+        state="DETACHED"
+    fi
 
     controllerResponse=$(query_ocp_api "apis/apps.openshift.io" "deploymentconfigs/${WORKBENCH_SERVICE_NAME}")
     controllerReplicas=$(echo ${controllerResponse:: -3} | python -c 'import json,sys;obj=json.load(sys.stdin);print (obj["spec"]["replicas"])')
     controllerAuth="$(echo -n "${KIE_ADMIN_USER}:${KIE_ADMIN_PWD}" | base64)"
 
     if [ ${kieReplicas} == 0 ]; then
-        log_info "KIE Server Replicas is ${kieReplicas}, updating ${KIE_SERVER_ID} configMap to DETACHED."
-        update_config_map "{\"metadata\":{\"labels\":{\"services.server.kie.org/kie-server-state\":\"DETACHED\"}}}" "${kieDCName}"
-
-        if [ "${controllerServiceHost}x" != "x" -a "${controllerServicePort}x" != "x" -a ${controllerReplicas} -gt 0  ]; then
+        # Normal scaling down scenario triggered by 'oc scale' command
+        if [ "$state" != "DETACHED" ]; then    
+            log_info "KIE Server Replicas is ${kieReplicas}, updating ${KIE_SERVER_ID} configMap to DETACHED."
+            update_config_map "{\"metadata\":{\"labels\":{\"services.server.kie.org/kie-server-state\":\"DETACHED\"}}}" "${kieCMName}"
+            check_state_loop "down"
+            sleep 10 # Wait for ServerTemplate cache to expire
+        fi
+        # Deleting KieServer DC scenario
+        if [ "$state" == "DETACHED" -a "${controllerServiceHost}x" != "x" -a "${controllerServicePort}x" != "x" -a ${controllerReplicas} -gt 0  ]; then
             # curl command may be hanging a bit during dc pod starting up; need to update
             # Pod.spec.terminationGracePeriodSeconds so as to safe guard infinite wait
             # and also accommodate bc Pod startup time.
@@ -51,24 +90,36 @@ if [ -n ${WORKBENCH_SERVICE_NAME} -a -n "${KIE_SERVER_ID}" ]; then
             curl --retry 12 --retry-delay 10 --retry-max-time 120 \
                 -s -X DELETE -i "http://${controllerServiceHost}:${controllerServicePort}/rest/controller/server/${KIE_SERVER_ID}" \
                 -H "Content-Type: application/json" \
-                -H "Authorization: Basic ${controllerAuth}"
+                -H "Authorization: Basic ${controllerAuth}" 
             log_info "Controller successfully notified"
+        else
+            log_warning "Notify Controller failed"
         fi
-
     elif [ ${kieReplicas} -gt 0 ]; then
-        log_info "KIE Server Replicas is ${kieReplicas}, updating ${KIE_SERVER_ID} configMap to USED."
-        update_config_map "{\"metadata\":{\"labels\":{\"services.server.kie.org/kie-server-state\":\"USED\"}}}" "${kieDCName}"
-
+        log_info "KIE Server Replicas is ${kieReplicas}, notifying Controller for KIE Server: [${KIE_SERVER_ID}]."
+        log_info "Waiting for KIE Server: [${KIE_SERVER_ID}] to scale up for 45 seconds..."
+        check_state_loop "up"
         if [ "${controllerServiceHost}x" != "x" -a "${controllerServicePort}x" != "x" -a ${controllerReplicas} -gt 0  ]; then
-            # curl command may be hanging a bit during dc pod starting up; need to update
-            # Pod.spec.terminationGracePeriodSeconds so as to safe guard infinite wait
-            # and also accommodate bc Pod startup time.
-            # try 12 times waiting 10 seconds for new retry, max allowed time is 120s
-            curl --retry 12 --retry-delay 10 --retry-max-time 120 \
-                -s -X PUT -i "http://${controllerServiceHost}:${controllerServicePort}/rest/controller/server/${KIE_SERVER_ID}" \
-                -H "Content-Type: application/json" \
-                -H "Authorization: Basic ${controllerAuth}"
+            if [ "$state" != "DETACHED" ]; then
+                # Normal scale up scenario
+                # curl command may be hanging a bit during dc pod starting up; need to update
+                # Pod.spec.terminationGracePeriodSeconds so as to safe guard infinite wait
+                # and also accommodate bc Pod startup time.
+                # try 12 times waiting 10 seconds for new retry, max allowed time is 120s
+                curl --retry 12 --retry-delay 10 --retry-max-time 120 \
+                    -s -X PUT -i "http://${controllerServiceHost}:${controllerServicePort}/rest/controller/server/${KIE_SERVER_ID}" \
+                    -H "Content-Type: application/json" \
+                    -H "Authorization: Basic ${controllerAuth}"
+            else
+                # Deleting KieServer DC scenario
+                curl --retry 12 --retry-delay 10 --retry-max-time 120 \
+                    -s -X DELETE -i "http://${controllerServiceHost}:${controllerServicePort}/rest/controller/server/${KIE_SERVER_ID}" \
+                    -H "Content-Type: application/json" \
+                    -H "Authorization: Basic ${controllerAuth}"
+            fi
             log_info "Controller successfully notified"
+        else
+            log_warning "Notify Controller failed"
         fi
     fi
 else

--- a/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver-hooks.bats
+++ b/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver-hooks.bats
@@ -36,13 +36,13 @@ export WORKBENCH_SERVICE_NAME="rhpam-central-console"
 @test "test container lifecycle hook - scale up scenario" {
     export KIE_SERVER_ID="rhpam-kieserevr-scale-up"
     run bash $BATS_TEST_DIRNAME/../../added/launch/jboss-kie-kieserver-hooks.sh
-    [ "${lines[0]}" = "[INFO]KIE Server Replicas is 1, updating rhpam-kieserevr-scale-up configMap to USED." ]
-    [ "${lines[1]}" = "[INFO]Controller successfully notified" ]
+    [ "${lines[0]}" = "[INFO]KIE Server Replicas is 1, notifying Controller for KIE Server: [rhpam-kieserevr-scale-up]." ]
+    [ "${lines[1]}" = "[INFO]Waiting for KIE Server: [rhpam-kieserevr-scale-up] to scale up for 45 seconds..." ]
+    [ "${lines[2]}" = "[INFO]Controller successfully notified" ]
 }
 
 @test "test container lifecycle hook - scale down scenario" {
     export KIE_SERVER_ID="rhpam-kieserevr-scale-down"
     run bash $BATS_TEST_DIRNAME/../../added/launch/jboss-kie-kieserver-hooks.sh
-    [ "${lines[0]}" = "[INFO]KIE Server Replicas is 0, updating rhpam-kieserevr-scale-down configMap to DETACHED." ]
-    [ "${lines[1]}" = "[INFO]Controller successfully notified" ]
+    [ "${lines[0]}" = "[INFO]Controller successfully notified" ]
 }


### PR DESCRIPTION
**_Issue Description_**
Given a kie controller and kie server deployed in the environment, and some containers deployed, when I scale down the kie server and then I scale it up again, then the kie controller loses the remote server (kie server url).

Related JIRA link:
https://issues.redhat.com/projects/RHPAM/issues/RHPAM-2634

Related PRs
https://github.com/jboss-container-images/jboss-kie-modules/pull/346
https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/411
https://github.com/kiegroup/kie-cloud-operator/pull/343

Signed-off-by: Evan Zhang <evan.zhang@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
