### PR TITLE
[RHPAM-2659] Honor GC_MAX_METASPACE_SIZE

### DIFF
--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -272,7 +272,9 @@ function configure_guvnor_settings() {
 # Set the max metaspace size only for the workbench
 # It avoid to set the max metaspace size if there is a multiple container instantiation.
 function configure_metaspace() {
-    export GC_MAX_METASPACE_SIZE=${WORKBENCH_MAX_METASPACE_SIZE:-1024}
+    if [ -z "${GC_MAX_METASPACE_SIZE}" ]; then
+        export GC_MAX_METASPACE_SIZE=${WORKBENCH_MAX_METASPACE_SIZE:-1024}
+    fi
 }
 
 # required envs for HA


### PR DESCRIPTION
Template is overriting GC_MAX_METASPACE_SIZE. Check first if value is already set.

https://issues.redhat.com/browse/RHPAM-2659