### PR TITLE
[RHPAM-2958] Set default JVM Max memory ratio to 80% in the images

### DIFF
--- a/jboss-kie-smartrouter/added/launch/jboss-kie-smartrouter.sh
+++ b/jboss-kie-smartrouter/added/launch/jboss-kie-smartrouter.sh
@@ -35,10 +35,16 @@ function configureEnv() {
 }
 
 function configure() {
+    configure_mem_ratio
     configure_router_state
     configure_router_location
     configure_controller_access
     configure_router_tls
+}
+
+function configure_mem_ratio() {
+    export JAVA_MAX_MEM_RATIO=${JAVA_MAX_MEM_RATIO:-80}
+    export JAVA_INITIAL_MEM_RATIO=${JAVA_INITIAL_MEM_RATIO:-25}
 }
 
 function configure_router_state() {

--- a/jboss-kie-smartrouter/tests/bats/jboss-kie-smartrouter.bats
+++ b/jboss-kie-smartrouter/tests/bats/jboss-kie-smartrouter.bats
@@ -34,3 +34,20 @@ teardown() {
   echo "Expected is ${expected}" >&2
   [[ $JBOSS_KIE_ARGS == *"-Dorg.kie.server.router.id=${expected}"* ]]
 }
+
+
+@test "verify if the JAVA_MAX_MEM_RATIO is set to 80 and JAVA_INITIAL_MEM_RATIO is set to 25" {
+    configure_mem_ratio
+    [[ "${JAVA_MAX_MEM_RATIO}" == 80 ]]
+    [[ "${JAVA_INITIAL_MEM_RATIO}" == 25 ]]
+}
+
+@test "verify if the JAVA_MAX_MEM_RATIO is set with the values passed" {
+    export JAVA_INITIAL_MEM_RATIO=10
+    export JAVA_MAX_MEM_RATIO=25
+    configure_mem_ratio
+    [[ "${JAVA_MAX_MEM_RATIO}" == 25 ]]
+    [[ "${JAVA_INITIAL_MEM_RATIO}" == 10 ]]
+    unset JAVA_INITIAL_MEM_RATIO
+    unset JAVA_MAX_MEM_RATIO
+}

--- a/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-common.sh
+++ b/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-common.sh
@@ -14,9 +14,15 @@ function configureEnv() {
 }
 
 function configure() {
+    configure_mem_ratio
     configure_maven_settings
     configure_mbeans
     configure_auth_login_modules
+}
+
+function configure_mem_ratio() {
+    export JAVA_MAX_MEM_RATIO=${JAVA_MAX_MEM_RATIO:-80}
+    export JAVA_INITIAL_MEM_RATIO=${JAVA_INITIAL_MEM_RATIO:-25}
 }
 
 function configure_maven_settings() {

--- a/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-common.bats
+++ b/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-common.bats
@@ -58,3 +58,19 @@ teardown() {
     echo $output
     [ "${JBOSS_KIE_ARGS}" = "${expected}" ]
 }
+
+@test "verify if the JAVA_MAX_MEM_RATIO is set to 80 and JAVA_INITIAL_MEM_RATIO is set to 25" {
+    configure_mem_ratio
+    [[ "${JAVA_MAX_MEM_RATIO}" == 80 ]]
+    [[ "${JAVA_INITIAL_MEM_RATIO}" == 25 ]]
+}
+
+@test "verify if the JAVA_MAX_MEM_RATIO is set with the values passed" {
+    export JAVA_INITIAL_MEM_RATIO=10
+    export JAVA_MAX_MEM_RATIO=25
+    configure_mem_ratio
+    [[ "${JAVA_MAX_MEM_RATIO}" == 25 ]]
+    [[ "${JAVA_INITIAL_MEM_RATIO}" == 10 ]]
+    unset JAVA_INITIAL_MEM_RATIO
+    unset JAVA_MAX_MEM_RATIO
+}

--- a/tests/features/rhpam/businesscentral-monitoring/rhpam-businesscentral-monitoring.feature
+++ b/tests/features/rhpam/businesscentral-monitoring/rhpam-businesscentral-monitoring.feature
@@ -46,3 +46,26 @@ Feature: RHPAM Business Central Monitoring configuration tests
      And container log should contain -Dorg.kie.server.controller.openshift.prefer.kieserver.service=true
      And container log should contain -Dorg.kie.server.controller.template.cache.ttl=10000
      And container log should contain -Dorg.kie.controller.ping.alive.disable=true
+
+  Scenario: Verify if the properties were correctly set using DEFAULT MEM RATIO
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 80, "JAVA_INITIAL_MEM_RATIO": 25} |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m
+
+  Scenario: Verify if the DEFAULT MEM RATIO properties are overridden with different values
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 50, "JAVA_INITIAL_MEM_RATIO": 10} |
+    Then container log should match regex -Xms51m
+    And container log should match regex -Xmx512m
+
+  Scenario: Verify if the properties were correctly set when aren't passed
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m

--- a/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
+++ b/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
@@ -61,3 +61,28 @@ Feature: RHPAM Business Central configuration tests
      And container log should contain -Dorg.uberfire.nio.git.http.enabled=true
      And container log should contain -Dorg.uberfire.nio.git.http.hostname=example.com
      And container log should contain -Dorg.uberfire.nio.git.http.port=80
+
+  Scenario: Verify if the properties were correctly set using DEFAULT MEM RATIO
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 80, "JAVA_INITIAL_MEM_RATIO": 25} |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m
+
+  Scenario: Verify if the DEFAULT MEM RATIO properties are overridden with different values
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 50, "JAVA_INITIAL_MEM_RATIO": 10} |
+    Then container log should match regex -Xms51m
+    And container log should match regex -Xmx512m
+
+  Scenario: Verify if the properties were correctly set when aren't passed
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m
+
+

--- a/tests/features/rhpam/controller/rhpam-controller.feature
+++ b/tests/features/rhpam/controller/rhpam-controller.feature
@@ -26,3 +26,26 @@ Feature: RHPAM Controller configuration tests
       | KIE_ADMIN_PWD              | custom" Adm!0 |
     Then file /opt/eap/standalone/configuration/application-users.properties should contain customAdm=a4d41e50a4ae17a50c1ceabe21e41a80
      And file /opt/eap/standalone/configuration/application-roles.properties should contain customAdm=kie-server,rest-all,admin,kiemgmt,Administrators
+
+  Scenario: Verify if the properties were correctly set using DEFAULT MEM RATIO
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 80, "JAVA_INITIAL_MEM_RATIO": 25} |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m
+
+  Scenario: Verify if the DEFAULT MEM RATIO properties are overridden with different values
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 50, "JAVA_INITIAL_MEM_RATIO": 10} |
+    Then container log should match regex -Xms51m
+    And container log should match regex -Xmx512m
+
+  Scenario: Verify if the properties were correctly set when aren't passed
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m

--- a/tests/features/rhpam/kieserver/rhpam-kieserver.feature
+++ b/tests/features/rhpam/kieserver/rhpam-kieserver.feature
@@ -980,3 +980,26 @@ Feature: RHPAM KIE Server configuration tests
     When container is ready
     Then run sh -c '[ $(ls -l /opt/eap/bin/launch/*.sh | wc -l) -gt 0 ] && echo "has script files"' in container and check its output for has script files
      And run sh -c 'exec=$(find -L /opt/eap/bin/launch -maxdepth 1 -type f -perm /u+x,g+x -name \*.sh | wc -l); nonexec=$(ls -l /opt/eap/bin/launch/*.sh | wc -l); [ $exec = $nonexec ] && echo "permissions ok"' in container and check its output for permissions ok
+
+  Scenario: Verify if the properties were correctly set using DEFAULT MEM RATIO
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 80, "JAVA_INITIAL_MEM_RATIO": 25} |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m
+
+  Scenario: Verify if the DEFAULT MEM RATIO properties are overridden with different values
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 50, "JAVA_INITIAL_MEM_RATIO": 10} |
+    Then container log should match regex -Xms51m
+     And container log should match regex -Xmx512m
+
+  Scenario: Verify if the properties were correctly set when aren't passed
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m

--- a/tests/features/rhpam/smartrouter/rhpam-smartrouter.feature
+++ b/tests/features/rhpam/smartrouter/rhpam-smartrouter.feature
@@ -126,3 +126,26 @@ Feature: RHPAM Smart Router configuration tests
       | SERVICE_ONE_SERVICE_PORT       | 10508        |
       | KIE_SERVER_CONTROLLER_PROTOCOL | http         |
     Then container log should contain -Dorg.kie.server.controller=http://10.1.1.12:10508
+
+  Scenario: Verify if the properties were correctly set using DEFAULT MEM RATIO
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 80, "JAVA_INITIAL_MEM_RATIO": 25} |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m
+    
+  Scenario: Verify if the DEFAULT MEM RATIO properties are overridden with different values
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 50, "JAVA_INITIAL_MEM_RATIO": 10} |
+    Then container log should match regex -Xms51m
+     And container log should match regex -Xmx512m
+
+  Scenario: Verify if the properties were correctly set when aren't passed
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+    Then container log should match regex -Xms205m
+     And container log should match regex -Xmx819m


### PR DESCRIPTION
https://issues.redhat.com/browse/RHPAM-2958
@spolti @jakubschwan 