### PR TITLE
[KIECLOUD-394]- Provide env switch for activating nio2.k8s FS and simplified user experience for BC-Monitoring

### DIFF
--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -173,6 +173,7 @@ function configure_openshift_enhancement() {
 }
 
 function configure_workbench_profile() {
+    local simplifiedMon=$(find_env "ORG_APPFORMER_SERVER_SIMPLIFIED_MONITORING_ENABLED" "false")
     # Business Central is unified for RHDM and RHPAM; For rhpam-decisioncentral needs to be set org.kie.workbench.profile
     # to FORCE_PLANNER_AND_RULES and for rhpam-businesscentral and rhpam-businesscentral-monitoring needst to be set to
     # FORCE_FULL
@@ -180,6 +181,7 @@ function configure_workbench_profile() {
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.workbench.profile=FORCE_PLANNER_AND_RULES"
     elif [[ $JBOSS_PRODUCT =~ rhpam\-businesscentral(\-monitoring)? ]]; then
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.workbench.profile=FORCE_FULL"
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.appformer.server.simplified.monitoring.enabled=${simplifiedMon}"
     fi
 }
 

--- a/tests/features/rhpam/businesscentral-monitoring/rhpam-businesscentral-monitoring.feature
+++ b/tests/features/rhpam/businesscentral-monitoring/rhpam-businesscentral-monitoring.feature
@@ -46,3 +46,11 @@ Feature: RHPAM Business Central Monitoring configuration tests
      And container log should contain -Dorg.kie.server.controller.openshift.prefer.kieserver.service=true
      And container log should contain -Dorg.kie.server.controller.template.cache.ttl=10000
      And container log should contain -Dorg.kie.controller.ping.alive.disable=true
+
+  # https://issues.redhat.com/projects/KIECLOUD/issues/KIECLOUD-394
+  Scenario: Check the simplifed monitoring switch is available
+    When container is started with env
+      | variable                                                 | value                     |
+      | ORG_APPFORMER_SERVER_SIMPLIFIED_MONITORING_ENABLED       | true                      |
+    Then container log should contain -Dorg.appformer.server.simplified.monitoring.enabled=true
+


### PR DESCRIPTION
As one of the few closing steps to close the OpenShift Re-architect initiative, by adding an environment variable as the switch for activating nio.k8s filesystem support as well as switching on a simplified version of Business Central Monitoring console which will eliminate the requirement for provisioning a ReadWriteMany PersistenceVolume while scaling out BC-M.

Related JIRAs:
https://issues.redhat.com/browse/KIECLOUD-394


Signed-off-by: Evan Zhang <evan.zhang@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
