### PR TITLE
[Rhpam 3211] Openshift properties related to passwords cannot use literal $n

### DIFF
--- a/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-security.bats
+++ b/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-security.bats
@@ -41,3 +41,52 @@ setup() {
     grep '^\#\$REALM_NAME=ApplicationRealm\$' "${APPLICATION_USERS_PROPERTIES}" > /dev/null 2>&1
     [ "$status" -eq 0 ]
 }
+
+@test "check if pwd password is set combination one" {
+    KIE_ADMIN_PWD=passw${0}rd
+    run get_kie_admin_pwd
+    [ "${KIE_ADMIN_PWD}" == "passw${0}rd" ]
+    unset KIE_ADMIN_PWD
+}
+
+@test "check if pwd password is set combination two" {
+    KIE_ADMIN_PWD=$0passwrd
+    run get_kie_admin_pwd
+    [ "${KIE_ADMIN_PWD}" == "$0passwrd" ]
+    unset KIE_ADMIN_PWD
+}
+
+@test "check if pwd password is set combination three" {
+    KIE_ADMIN_PWD=${0}passwrd
+    run get_kie_admin_pwd
+    [ "${KIE_ADMIN_PWD}" == "${0}passwrd" ]
+    unset KIE_ADMIN_PWD
+}
+
+@test "check if pwd password is set combination four" {
+    KIE_ADMIN_PWD=passw${0}rd
+    run get_kie_admin_pwd
+    [ "${KIE_ADMIN_PWD}" == "passw${0}rd" ]
+    unset KIE_ADMIN_PWD
+}
+
+@test "check if pwd password is set combination five" {
+    KIE_ADMIN_PWD=\'$0\'passwrd
+    run get_kie_admin_pwd
+    [ "${KIE_ADMIN_PWD}" == "'$0'passwrd" ]
+    unset KIE_ADMIN_PWD
+}
+
+@test "check if pwd password is set combination six" {
+    KIE_ADMIN_PWD=\'${0}\'passwrd
+    run get_kie_admin_pwd
+    [ "${KIE_ADMIN_PWD}" == "'${0}'passwrd" ]
+    unset KIE_ADMIN_PWD
+}
+
+@test "check if pwd password replaced wth two evalutaion" {
+    KIE_ADMIN_PWD=$0passwrd
+    run get_kie_admin_pwd
+    [ "${KIE_ADMIN_PWD}" == "'${0}'passwrd" ]
+    unset KIE_ADMIN_PWD
+}

--- a/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-security.bats
+++ b/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-security.bats
@@ -45,6 +45,7 @@ setup() {
 @test "check if pwd password is set combination one" {
     KIE_ADMIN_PWD=passw${0}rd
     run get_kie_admin_pwd
+    [[ ${lines[0]} == "passw${0}rd" ]]
     [ "${KIE_ADMIN_PWD}" == "passw${0}rd" ]
     unset KIE_ADMIN_PWD
 }
@@ -52,6 +53,7 @@ setup() {
 @test "check if pwd password is set combination two" {
     KIE_ADMIN_PWD=$0passwrd
     run get_kie_admin_pwd
+    [[ ${lines[0]} == "$0passwrd" ]]
     [ "${KIE_ADMIN_PWD}" == "$0passwrd" ]
     unset KIE_ADMIN_PWD
 }
@@ -59,6 +61,7 @@ setup() {
 @test "check if pwd password is set combination three" {
     KIE_ADMIN_PWD=${0}passwrd
     run get_kie_admin_pwd
+    [[ ${lines[0]} == "${0}passwrd" ]]
     [ "${KIE_ADMIN_PWD}" == "${0}passwrd" ]
     unset KIE_ADMIN_PWD
 }
@@ -66,6 +69,7 @@ setup() {
 @test "check if pwd password is set combination four" {
     KIE_ADMIN_PWD=passw${0}rd
     run get_kie_admin_pwd
+    [[ ${lines[0]} == "passw${0}rd" ]]
     [ "${KIE_ADMIN_PWD}" == "passw${0}rd" ]
     unset KIE_ADMIN_PWD
 }
@@ -73,6 +77,7 @@ setup() {
 @test "check if pwd password is set combination five" {
     KIE_ADMIN_PWD=\'$0\'passwrd
     run get_kie_admin_pwd
+    [[ ${lines[0]} == "'$0'passwrd" ]]
     [ "${KIE_ADMIN_PWD}" == "'$0'passwrd" ]
     unset KIE_ADMIN_PWD
 }
@@ -80,13 +85,7 @@ setup() {
 @test "check if pwd password is set combination six" {
     KIE_ADMIN_PWD=\'${0}\'passwrd
     run get_kie_admin_pwd
-    [ "${KIE_ADMIN_PWD}" == "'${0}'passwrd" ]
-    unset KIE_ADMIN_PWD
-}
-
-@test "check if pwd password replaced wth two evalutaion" {
-    KIE_ADMIN_PWD=$0passwrd
-    run get_kie_admin_pwd
+    [[ ${lines[0]} == "'${0}'passwrd" ]]
     [ "${KIE_ADMIN_PWD}" == "'${0}'passwrd" ]
     unset KIE_ADMIN_PWD
 }

--- a/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-security.bats
+++ b/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-security.bats
@@ -46,7 +46,6 @@ setup() {
     KIE_ADMIN_PWD=passw${0}rd
     run get_kie_admin_pwd
     [[ ${lines[0]} == "passw${0}rd" ]]
-    [ "${KIE_ADMIN_PWD}" == "passw${0}rd" ]
     unset KIE_ADMIN_PWD
 }
 
@@ -54,7 +53,6 @@ setup() {
     KIE_ADMIN_PWD=$0passwrd
     run get_kie_admin_pwd
     [[ ${lines[0]} == "$0passwrd" ]]
-    [ "${KIE_ADMIN_PWD}" == "$0passwrd" ]
     unset KIE_ADMIN_PWD
 }
 
@@ -62,7 +60,6 @@ setup() {
     KIE_ADMIN_PWD=${0}passwrd
     run get_kie_admin_pwd
     [[ ${lines[0]} == "${0}passwrd" ]]
-    [ "${KIE_ADMIN_PWD}" == "${0}passwrd" ]
     unset KIE_ADMIN_PWD
 }
 
@@ -70,7 +67,6 @@ setup() {
     KIE_ADMIN_PWD=passw${0}rd
     run get_kie_admin_pwd
     [[ ${lines[0]} == "passw${0}rd" ]]
-    [ "${KIE_ADMIN_PWD}" == "passw${0}rd" ]
     unset KIE_ADMIN_PWD
 }
 
@@ -78,7 +74,6 @@ setup() {
     KIE_ADMIN_PWD=\'$0\'passwrd
     run get_kie_admin_pwd
     [[ ${lines[0]} == "'$0'passwrd" ]]
-    [ "${KIE_ADMIN_PWD}" == "'$0'passwrd" ]
     unset KIE_ADMIN_PWD
 }
 
@@ -86,6 +81,5 @@ setup() {
     KIE_ADMIN_PWD=\'${0}\'passwrd
     run get_kie_admin_pwd
     [[ ${lines[0]} == "'${0}'passwrd" ]]
-    [ "${KIE_ADMIN_PWD}" == "'${0}'passwrd" ]
     unset KIE_ADMIN_PWD
 }

--- a/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
+++ b/tests/features/rhpam/businesscentral/rhpam-businesscentral.feature
@@ -85,4 +85,20 @@ Feature: RHPAM Business Central configuration tests
     Then container log should match regex -Xms205m
      And container log should match regex -Xmx819m
 
+  Scenario: Verify if the PWD is escaped
+    When container is started with env
+      | variable                   | value         |
+      | KIE_ADMIN_USER             | customAdm     |
+      | KIE_ADMIN_PWD              | passw${0}rd   |
+      | SCRIPT_DEBUG               | true          |
+    Then container log should match regex passw${0}rd
+
+  Scenario: Verify if the PWD is set correctly
+    When container is started with env
+      | variable                   | value         |
+      | KIE_ADMIN_USER             | customAdm     |
+      | KIE_ADMIN_PWD              | passw$0rd   |
+      | SCRIPT_DEBUG               | true          |
+    Then container log should match regex passw$0rd
+
 

--- a/tests/features/rhpam/smartrouter/rhpam-smartrouter.feature
+++ b/tests/features/rhpam/smartrouter/rhpam-smartrouter.feature
@@ -172,3 +172,57 @@ Feature: RHPAM Smart Router configuration tests
      And file /opt/rhpam-smartrouter/logging.properties should contain org.xyz=INFO
      And file /opt/rhpam-smartrouter/logging.properties should contain SEVERE
 
+  Scenario: Verify if the passw$0rd is correctly set
+    When container is started with env
+      | variable                                  | value        |
+      | SCRIPT_DEBUG                              | true         |
+      | KIE_ADMIN_PWD                             | passw$0rd  |
+      | KIE_ADMIN_USER                            | userA        |
+    Then container log should contain org.kie.server.controller.user = userA
+    And container log should contain org.kie.server.controller.pwd = passw$0rd
+
+  Scenario: Verify if the passw${0}rd is correctly set
+    When container is started with env
+      | variable                                  | value        |
+      | SCRIPT_DEBUG                              | true         |
+      | KIE_ADMIN_PWD                             | passw${0}rd  |
+      | KIE_ADMIN_USER                            | userA        |
+    Then container log should contain org.kie.server.controller.user = userA
+    And container log should contain org.kie.server.controller.pwd = passw${0}rd
+
+  Scenario: Verify if the $0password is correctly set
+    When container is started with env
+      | variable                                  | value        |
+      | SCRIPT_DEBUG                              | true         |
+      | KIE_ADMIN_PWD                             | $0password  |
+      | KIE_ADMIN_USER                            | userA        |
+    Then container log should contain org.kie.server.controller.user = userA
+    And container log should contain org.kie.server.controller.pwd = $0password
+
+  Scenario: Verify if the ${0}password is correctly set
+    When container is started with env
+      | variable                                  | value        |
+      | SCRIPT_DEBUG                              | true         |
+      | KIE_ADMIN_PWD                             | ${0}password  |
+      | KIE_ADMIN_USER                            | userA        |
+    Then container log should contain org.kie.server.controller.user = userA
+    And container log should contain org.kie.server.controller.pwd = ${0}password
+
+  Scenario: Verify if the passw$1rd  is correctly set
+    When container is started with env
+      | variable                                  | value        |
+      | SCRIPT_DEBUG                              | true         |
+      | KIE_ADMIN_PWD                             | passw$1rd  |
+      | KIE_ADMIN_USER                            | userA        |
+    Then container log should contain org.kie.server.controller.user = userA
+    And container log should contain org.kie.server.controller.pwd = passw$1rd
+
+  Scenario: Verify if the passw${1}rd  is correctly set
+    When container is started with env
+      | variable                                  | value        |
+      | SCRIPT_DEBUG                              | true         |
+      | KIE_ADMIN_PWD                             | passw${1}rd  |
+      | KIE_ADMIN_USER                            | userA        |
+    Then container log should contain org.kie.server.controller.user = userA
+    And container log should contain org.kie.server.controller.pwd = passw${1}rd
+


### PR DESCRIPTION
https://issues.redhat.com/browse/RHPAM-3211
