### PR TITLE
[RHPAM-3300] - Add EJB timer related settings in OCP to avoid duplicate timer execution

### DIFF
--- a/tests/features/rhpam/rhpam-kieserver.feature
+++ b/tests/features/rhpam/rhpam-kieserver.feature
@@ -45,7 +45,6 @@ Feature: RHPAM KIE Server configuration tests
       | variable                 | value |
       | JBPM_LOOP_LEVEL_DISABLED | true  |
     Then container log should not contain -Dorg.jbpm.server.ext.disabled=true
-     And container log should contain -Dorg.jbpm.ejb.timer.tx=true
      And container log should contain -Djbpm.loop.level.disabled=true
 
   Scenario: Check for the default ejb timer's setup behavior


### PR DESCRIPTION
Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
