### PR TITLE
[RHPAM-3326] - Defaul value for MaxMetaspaceSize in Operator overried…

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -69,6 +69,7 @@ function configure() {
     configure_jbpm
     configure_kie_server_mgmt
     configure_mode
+    configure_metaspace
     configure_prometheus
     configure_optaplanner
     # configure_server_state always has to be last
@@ -430,6 +431,13 @@ function configure_router_access {
         local kieServerRouterUrl=$(build_simple_url "${kieServerRouterProtocol}" "${kieServerRouterHost}" "${kieServerRouterPort}" "")
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.router=${kieServerRouterUrl}"
     fi
+}
+
+# Set the max metaspace size for the kieserver
+# It avoid to set the max metaspace size if there is a multiple container instantiation.
+function configure_metaspace() {
+    local gcMaxMetaspace=${GC_MAX_METASPACE_SIZE:-512}
+    export GC_MAX_METASPACE_SIZE=${KIE_SERVER_MAX_METASPACE_SIZE:-${gcMaxMetaspace}}
 }
 
 function configure_drools() {

--- a/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
+++ b/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
@@ -589,3 +589,30 @@ teardown() {
     [[ "${JBOSS_KIE_ARGS}" == "${expected}" ]]
 }
 
+@test "verify if the GC_MAX_METASPACE_SIZE is set to 512 if KIE_SERVER_MAX_METASPACE_SIZE is not set" {
+    configure_metaspace
+    echo "GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE}"
+    [[ "${GC_MAX_METASPACE_SIZE}" == "512" ]]
+}
+
+@test "verify if the KIE_SERVER_MAX_METASPACE_SIZE is correctly set" {
+    export KIE_SERVER_MAX_METASPACE_SIZE="2048"
+    configure_metaspace
+    echo "GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE}"
+    [[ "${GC_MAX_METASPACE_SIZE}" == "2048" ]]
+}
+
+@test "verify if the GC_MAX_METASPACE_SIZE is correctly set and bypass KIE_SERVER_MAX_METASPACE_SIZE env" {
+    export GC_MAX_METASPACE_SIZE="4096"
+    configure_metaspace
+    echo "GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE}"
+    [[ "${GC_MAX_METASPACE_SIZE}" == "4096" ]]
+}
+
+@test "verify if the KIE_SERVER_MAX_METASPACE_SIZE takes precedence when KIESERVER_MAX_METASPACE_SIZE and GC_MAX_METASPACE_SIZE are set" {
+    export KIE_SERVER_MAX_METASPACE_SIZE="4096"
+    export GC_MAX_METASPACE_SIZE="2048"
+    configure_metaspace
+    echo "GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE}"
+    [[ "${GC_MAX_METASPACE_SIZE}" == "${KIE_SERVER_MAX_METASPACE_SIZE}" ]]
+}

--- a/tests/features/common/kie-kieserver-common.feature
+++ b/tests/features/common/kie-kieserver-common.feature
@@ -470,7 +470,7 @@ Feature: Kie Server common features
   Scenario: Check if the KIE_SERVER_MAX_METASPACE_SIZE is correctly set
     When container is started with env
       | variable                       | value   |
-      | KIE_SERVER_MAX_METASPACE_SIZE   | 2048    |
+      | KIE_SERVER_MAX_METASPACE_SIZE  | 2048    |
     Then container log should contain -XX:MaxMetaspaceSize=2048m
 
   Scenario: Check if the GC_MAX_METASPACE_SIZE is correctly set and bypass KIE_SERVER_MAX_METASPACE_SIZE env
@@ -482,6 +482,6 @@ Feature: Kie Server common features
   Scenario: Check if the WORKBENCH_MAX_METASPACE_SIZE takes precedence when KIE_SERVER_MAX_METASPACE_SIZE and GC_MAX_METASPACE_SIZE are set
     When container is started with env
       | variable                       | value   |
-      | KIE_SERVER_MAX_METASPACE_SIZE   | 4096    |
+      | KIE_SERVER_MAX_METASPACE_SIZE  | 4096    |
       | GC_MAX_METASPACE_SIZE          | 2048    |
     Then container log should contain -XX:MaxMetaspaceSize=4096m

--- a/tests/features/common/kie-kieserver-common.feature
+++ b/tests/features/common/kie-kieserver-common.feature
@@ -463,3 +463,25 @@ Feature: Kie Server common features
     And file /home/jboss/.m2/settings.xml should contain <url>http://nexus-test.127.0.0.1.nip.ip/nexus/</url>
     And file /home/jboss/.m2/settings.xml should contain <mirrorOf>external:*</mirrorOf>
 
+  Scenario: Check if the GC_MAX_METASPACE_SIZE is set to 512 if KIE_SERVER_MAX_METASPACE_SIZE is not set
+    When container is ready
+    Then container log should contain -XX:MaxMetaspaceSize=512m
+
+  Scenario: Check if the KIE_SERVER_MAX_METASPACE_SIZE is correctly set
+    When container is started with env
+      | variable                       | value   |
+      | KIE_SERVER_MAX_METASPACE_SIZE   | 2048    |
+    Then container log should contain -XX:MaxMetaspaceSize=2048m
+
+  Scenario: Check if the GC_MAX_METASPACE_SIZE is correctly set and bypass KIE_SERVER_MAX_METASPACE_SIZE env
+    When container is started with env
+      | variable                | value   |
+      | GC_MAX_METASPACE_SIZE   | 4096    |
+    Then container log should contain -XX:MaxMetaspaceSize=4096m
+
+  Scenario: Check if the WORKBENCH_MAX_METASPACE_SIZE takes precedence when KIE_SERVER_MAX_METASPACE_SIZE and GC_MAX_METASPACE_SIZE are set
+    When container is started with env
+      | variable                       | value   |
+      | KIE_SERVER_MAX_METASPACE_SIZE   | 4096    |
+      | GC_MAX_METASPACE_SIZE          | 2048    |
+    Then container log should contain -XX:MaxMetaspaceSize=4096m


### PR DESCRIPTION
…s default values set by image scripts

See: https://issues.redhat.com/browse/RHPAM-3326

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
