### PR TITLE
[KIECLOUD -  479] - Updated EJB Timer related env vars to have same pattern

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -14,14 +14,14 @@ function prepareEnv() {
     unset JBPM_HT_CALLBACK_METHOD
     unset JBPM_LOOP_LEVEL_DISABLED
     unset KIE_EXECUTOR_RETRIES
+    unset JBPM_EJB_TIMER_LOCAL_CACHE
+    unset JBPM_EJB_TIMER_TX
     unset_kie_security_env
     unset KIE_SERVER_CONTAINER_DEPLOYMENT
     unset KIE_SERVER_CONTROLLER_HOST
     unset KIE_SERVER_CONTROLLER_PORT
     unset KIE_SERVER_CONTROLLER_PROTOCOL
     unset KIE_SERVER_CONTROLLER_SERVICE
-    unset KIE_EJB_TIMER_LOCAL_CACHE
-    unset KIE_EJB_TIMER_TX
     unset KIE_SERVER_HOST
     unset KIE_SERVER_ID
     unset KIE_SERVER_LOCATION
@@ -123,8 +123,8 @@ function configure_EJB_Timer_datasource {
     fi
 
     if [ -n "${TIMER_SERVICE_DATA_STORE}" ]; then
-        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.jbpm.ejb.timer.tx=${KIE_EJB_TIMER_TX:-true}"
-        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.jbpm.ejb.timer.local.cache=${KIE_EJB_TIMER_LOCAL_CACHE:-false}"
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.jbpm.ejb.timer.tx=${JBPM_EJB_TIMER_TX:-true}"
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.jbpm.ejb.timer.local.cache=${JBPM_EJB_TIMER_LOCAL_CACHE:-false}"
     fi
 }
 

--- a/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
+++ b/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
@@ -80,8 +80,8 @@ teardown() {
 
 @test "verify if EJB_TIMER related settings are changed" {
   local TIMER_SERVICE_DATA_STORE="EJB_TIMER"
-  local KIE_EJB_TIMER_TX="false"
-  local KIE_EJB_TIMER_LOCAL_CACHE="true"
+  local JBPM_EJB_TIMER_TX="false"
+  local JBPM_EJB_TIMER_LOCAL_CACHE="true"
   local expected_ejb_timer_tx="-Dorg.jbpm.ejb.timer.tx=false"
   local expected_ejb_timer_local_cache="-Dorg.jbpm.ejb.timer.local.cache=true"
   configure_EJB_Timer_datasource >&2


### PR DESCRIPTION
… in KIE Server

See: https://issues.redhat.com/browse/KIECLOUD-479

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
