### PR TITLE
[RHPAM-3248] - Provision Dashbuilder image with operator

### DIFF
--- a/jboss-kie-dashbuilder/configure.sh
+++ b/jboss-kie-dashbuilder/configure.sh
@@ -11,7 +11,7 @@ mkdir -p ${JBOSS_HOME}/bin/launch
 cp -r ${ADDED_DIR}/launch/* ${JBOSS_HOME}/bin/launch
 chmod ug+x ${JBOSS_HOME}/bin/openshift-launch.sh
 
-mkdir -p /opt/kie/data/{imports,components}
+mkdir -p /opt/kie/dashbuilder/{imports,components}
 chown -R jboss:root /opt/kie
 
 # Set bin permissions

--- a/jboss-kie-dashbuilder/tests/bats/jboss-kie-dashbuilder.bats
+++ b/jboss-kie-dashbuilder/tests/bats/jboss-kie-dashbuilder.bats
@@ -92,7 +92,7 @@ configure_dashbuilder_auth() {
 
     echo "Result: ${JBOSS_KIE_DASHBUILDER_ARGS}"
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" != "dashbuilder.runtime.import"* ]]
-    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/data/imports"* ]]
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports"* ]]
 }
 
 @test "test configure_dashbuilder_file_imports function with valid DASHBUILDER_IMPORTS_BASE_DIR env" {
@@ -112,7 +112,7 @@ configure_dashbuilder_auth() {
 
     echo "Result: ${JBOSS_KIE_DASHBUILDER_ARGS}"
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" != "dashbuilder.runtime.import"* ]]
-    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/data/imports"* ]]
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports"* ]]
 }
 
 @test "test configure_dashbuilder_file_imports function with DASHBUILDER_MODEL_UPDATE env" {
@@ -122,7 +122,7 @@ configure_dashbuilder_auth() {
 
     echo "Result: ${JBOSS_KIE_DASHBUILDER_ARGS}"
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" != "dashbuilder.runtime.import"* ]]
-    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/data/imports"* ]]
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports"* ]]
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.model.update=false"* ]]
 }
 
@@ -131,7 +131,7 @@ configure_dashbuilder_auth() {
 
     echo "Result: ${JBOSS_KIE_DASHBUILDER_ARGS}"
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" != "dashbuilder.runtime.import"* ]]
-    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/data/imports"* ]]
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports"* ]]
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.removeModelFile=false"* ]]
 }
 
@@ -142,7 +142,7 @@ configure_dashbuilder_auth() {
 
     echo "Result: ${JBOSS_KIE_DASHBUILDER_ARGS}"
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" != "dashbuilder.runtime.import"* ]]
-    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/data/imports"* ]]
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports"* ]]
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.removeModelFile=true"* ]]
 }
 
@@ -153,7 +153,7 @@ configure_dashbuilder_auth() {
 
     echo "Result: ${JBOSS_KIE_DASHBUILDER_ARGS}"
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" != "dashbuilder.runtime.import"* ]]
-    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/data/imports"* ]]
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports"* ]]
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.removeModelFile=false"* ]]
 }
 
@@ -194,17 +194,15 @@ configure_dashbuilder_auth() {
 
 
 @test "test configure_dashbuilder_external_component with default component dir" {
-    export DASHBUILDER_COMP_ENABLE="true"
 
     configure_dashbuilder_external_component
 
     echo "Result: ${JBOSS_KIE_DASHBUILDER_ARGS}"
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.components.enable=true"* ]]
-    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.components.dir=/opt/kie/data/components"* ]]
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.components.dir=/opt/kie/dashbuilder/components"* ]]
 }
 
 @test "test configure_dashbuilder_external_component with custom component dir" {
-    export DASHBUILDER_COMP_ENABLE="true"
     export DASHBUILDER_EXTERNAL_COMP_DIR="/tmp"
 
     configure_dashbuilder_external_component
@@ -215,19 +213,27 @@ configure_dashbuilder_auth() {
 }
 
 @test "test configure_dashbuilder_external_component with nonsense component dir" {
-    export DASHBUILDER_COMP_ENABLE="true"
     export DASHBUILDER_EXTERNAL_COMP_DIR="nonsense"
 
     configure_dashbuilder_external_component
 
     echo "Result: ${JBOSS_KIE_DASHBUILDER_ARGS}"
     [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.components.enable=true"* ]]
-    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.components.dir=/opt/kie/data/components"* ]]
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.components.dir=/opt/kie/dashbuilder/components"* ]]
+}
+
+@test "test configure_dashbuilder_external_component with component set to false" {
+    export DASHBUILDER_COMP_ENABLE="false"
+    configure_dashbuilder_external_component
+
+    echo "Result: ${JBOSS_KIE_DASHBUILDER_ARGS}"
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" = *" -Ddashbuilder.components.enable=false"* ]]
+    [[ "${JBOSS_KIE_DASHBUILDER_ARGS}" != *" -Ddashbuilder.components.dir=/opt/kie/dashbuilder/components"* ]]
 }
 
 @test "test configuration with config_map" {
     export DASHBUILDER_CONFIG_MAP_PROPS="$BATS_TEST_DIRNAME/props/dashbuilder.properties"
-    expected="-Ddashbuilder.runtime.allowExternal=true -Ddashbuilder.components.partition=true -Ddashbuilder.dataset.partition=true -Ddashbuilder.import.base.dir=/opt/kie/data/imports -Ddashbuilder.removeModelFile=false -Ddashbuilder.runtime.multi=true -Ddashbuilder.runtime.import=/tmp -Ddashbuilder.runtime.upload.size=1000"
+    expected="-Ddashbuilder.runtime.allowExternal=true -Ddashbuilder.components.partition=true -Ddashbuilder.dataset.partition=true -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports -Ddashbuilder.removeModelFile=false -Ddashbuilder.runtime.multi=true -Ddashbuilder.components.enable=true -Ddashbuilder.components.dir=/opt/kie/dashbuilder/components -Ddashbuilder.runtime.import=/tmp -Ddashbuilder.runtime.upload.size=1000"
 
     configure
 
@@ -293,7 +299,7 @@ configure_dashbuilder_auth() {
     export dataset_test_USER="moon"
     export dataset_test_PASSWORD="sun"
 
-    expected="-Ddashbuilder.runtime.allowExternal=false -Ddashbuilder.components.partition=true -Ddashbuilder.dataset.partition=true -Ddashbuilder.import.base.dir=/opt/kie/data/imports -Ddashbuilder.removeModelFile=false -Ddashbuilder.runtime.multi=false -Ddashbuilder.kieserver.dataset.dataset_test.location=http://localmoon.com -Ddashbuilder.kieserver.dataset.dataset_test.replace_query=false -Ddashbuilder.kieserver.dataset.dataset_test.user=moon -Ddashbuilder.kieserver.dataset.dataset_test.password=sun -Ddashbuilder.kieserver.dataset.DataSetTest.location=http://localmoon.com -Ddashbuilder.kieserver.dataset.DataSetTest.user=test -Ddashbuilder.kieserver.dataset.DataSetTest.password=test_pwd"
+    expected="-Ddashbuilder.runtime.allowExternal=false -Ddashbuilder.components.partition=true -Ddashbuilder.dataset.partition=true -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports -Ddashbuilder.removeModelFile=false -Ddashbuilder.runtime.multi=false -Ddashbuilder.components.enable=true -Ddashbuilder.components.dir=/opt/kie/dashbuilder/components -Ddashbuilder.kieserver.dataset.dataset_test.location=http://localmoon.com -Ddashbuilder.kieserver.dataset.dataset_test.replace_query=false -Ddashbuilder.kieserver.dataset.dataset_test.user=moon -Ddashbuilder.kieserver.dataset.dataset_test.password=sun -Ddashbuilder.kieserver.dataset.DataSetTest.location=http://localmoon.com -Ddashbuilder.kieserver.dataset.DataSetTest.user=test -Ddashbuilder.kieserver.dataset.DataSetTest.password=test_pwd"
 
     configure
 
@@ -331,6 +337,26 @@ configure_dashbuilder_auth() {
     [ "${JBOSS_KIE_DASHBUILDER_ARGS}" = "${expected}" ]
 }
 
+@test "test Kie Server server template and dataset with dash" {
+    export KIESERVER_SERVER_TEMPLATES="Server-Template-Test"
+    export Server_Template_Test_LOCATION="http://localmoon.com"
+    export Server_Template_Test_TOKEN="my_cool_token"
+
+    export KIESERVER_DATASETS="dataset-test"
+    export dataset_test_LOCATION="http://localmoon.com"
+    export dataset_test_USER="moon"
+    export dataset_test_PASSWORD="sun"
+
+    expected=" -Ddashbuilder.kieserver.serverTemplate.Server-Template-Test.location=http://localmoon.com -Ddashbuilder.kieserver.serverTemplate.Server-Template-Test.replace_query=false -Ddashbuilder.kieserver.serverTemplate.Server-Template-Test.token=my_cool_token -Ddashbuilder.kieserver.dataset.dataset-test.location=http://localmoon.com -Ddashbuilder.kieserver.dataset.dataset-test.replace_query=false -Ddashbuilder.kieserver.dataset.dataset-test.user=moon -Ddashbuilder.kieserver.dataset.dataset-test.password=sun"
+
+    configure_dashbuilder_kieserver_server_template
+    configure_dashbuilder_kieserver_dataset
+
+    echo "Result  : ${JBOSS_KIE_DASHBUILDER_ARGS}"
+    echo "Expected: ${expected}"
+    [ "${JBOSS_KIE_DASHBUILDER_ARGS}" = "${expected}" ]
+}
+
 @test "test multiple Kie Server server template with credentials and token" {
     export KIESERVER_SERVER_TEMPLATES="server_template_test,ServerTemplateTest"
     export server_template_test_LOCATION="http://localmoon.com"
@@ -355,7 +381,7 @@ configure_dashbuilder_auth() {
     export server_template_test_USER="moon"
     export server_template_test_PASSWORD="sun"
 
-    expected="-Ddashbuilder.runtime.allowExternal=false -Ddashbuilder.components.partition=true -Ddashbuilder.dataset.partition=true -Ddashbuilder.import.base.dir=/opt/kie/data/imports -Ddashbuilder.removeModelFile=false -Ddashbuilder.runtime.multi=false -Ddashbuilder.kieserver.serverTemplate.server_template_test.location=http://localmoon.com -Ddashbuilder.kieserver.serverTemplate.server_template_test.replace_query=false -Ddashbuilder.kieserver.serverTemplate.server_template_test.user=moon -Ddashbuilder.kieserver.serverTemplate.server_template_test.password=sun -Ddashbuilder.kieserver.serverTemplate.ServerTemplateTest.location=http://localmoon.com -Ddashbuilder.kieserver.serverTemplate.ServerTemplateTest.user=test -Ddashbuilder.kieserver.serverTemplate.ServerTemplateTest.password=test_pwd"
+    expected="-Ddashbuilder.runtime.allowExternal=false -Ddashbuilder.components.partition=true -Ddashbuilder.dataset.partition=true -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports -Ddashbuilder.removeModelFile=false -Ddashbuilder.runtime.multi=false -Ddashbuilder.components.enable=true -Ddashbuilder.components.dir=/opt/kie/dashbuilder/components -Ddashbuilder.kieserver.serverTemplate.server_template_test.location=http://localmoon.com -Ddashbuilder.kieserver.serverTemplate.server_template_test.replace_query=false -Ddashbuilder.kieserver.serverTemplate.server_template_test.user=moon -Ddashbuilder.kieserver.serverTemplate.server_template_test.password=sun -Ddashbuilder.kieserver.serverTemplate.ServerTemplateTest.location=http://localmoon.com -Ddashbuilder.kieserver.serverTemplate.ServerTemplateTest.user=test -Ddashbuilder.kieserver.serverTemplate.ServerTemplateTest.password=test_pwd"
 
     configure
 

--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -29,6 +29,8 @@ function prepareEnv() {
     unset BUILD_ENABLE_INCREMENTAL
     unset GIT_HOOKS_DIR
     unset_kie_security_env
+    unset KIE_DASHBUILDER_RUNTIME_LOCATION
+    unset KIE_DASHBUILDER_EXPORT_DIR
     unset KIE_SERVER_CONTROLLER_HOST
     unset KIE_SERVER_CONTROLLER_OPENSHIFT_ENABLED
     unset KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
@@ -39,6 +41,8 @@ function prepareEnv() {
     unset KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
     unset KIE_M2_REPO_DIR
     unset KIE_PERSIST_MAVEN_REPO
+
+
 }
 
 function preConfigure() {
@@ -54,6 +58,7 @@ function configure() {
     # before any direct or indirect calls to add_eap_user
     configure_local_security
     configure_admin_security
+    configure_dashbuilder
     configure_kie_keystore
     configure_controller_access
     configure_server_access
@@ -79,6 +84,13 @@ function configure_admin_security() {
     # rhpam-businesscentral, rhpam-businesscentral-monitoring
     if [[ $JBOSS_PRODUCT =~ rhpam\-businesscentral(\-monitoring)? ]]; then
         configure_login_modules "org.kie.security.jaas.KieLoginModule" "optional" "deployment.ROOT.war"
+    fi
+}
+
+function configure_dashbuilder() {
+    local kieDataDir="/opt/kie/data"
+    if [ "${KIE_DASHBUILDER_RUNTIME_LOCATION}x" != "x" ]; then
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Ddashbuilder.runtime.location=${KIE_DASHBUILDER_RUNTIME_LOCATION} -Ddashbuilder.export.dir=${kieDataDir}/dash"
     fi
 }
 

--- a/jboss-kie-workbench/tests/bats/jboss-kie-workbench.bats
+++ b/jboss-kie-workbench/tests/bats/jboss-kie-workbench.bats
@@ -136,3 +136,15 @@ teardown() {
     echo "Result: ${MAVEN_LOCAL_REPO}"
     [ "${MAVEN_LOCAL_REPO}" = "/tmp/test/123" ]
 }
+
+@test "test if the dashbuilder properties will be correctly set." {
+    export KIE_DASHBUILDER_RUNTIME_LOCATION="http://dashbuilder:8080"
+    expected=" -Ddashbuilder.runtime.location=http://dashbuilder:8080 -Ddashbuilder.export.dir=/opt/kie/data/dash"
+
+    configure_dashbuilder
+
+    echo "Expected: ${expected}"
+    echo "Result  : ${JBOSS_KIE_ARGS}"
+
+    [ "${JBOSS_KIE_ARGS}" = "${expected}" ]
+}

--- a/tests/features/rhpam/rhpam-dashbuilder.feature
+++ b/tests/features/rhpam/rhpam-dashbuilder.feature
@@ -39,7 +39,7 @@ Feature: RHPAM Dashbuilder Runtime configuration tests
     Then container log should contain -Ddashbuilder.runtime.allowExternal=false
      And container log should contain -Ddashbuilder.components.partition=true
      And container log should contain -Ddashbuilder.dataset.partition=true
-     And container log should contain -Ddashbuilder.import.base.dir=/opt/kie/data/imports
+     And container log should contain -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports
      And container log should contain -Ddashbuilder.removeModelFile=false
      And container log should contain -Ddashbuilder.runtime.multi=false
 
@@ -63,12 +63,12 @@ Feature: RHPAM Dashbuilder Runtime configuration tests
       | DASHBUILDER_IMPORT_FILE_LOCATION | /tmp/test.zip |
     Then container log should contain -Ddashbuilder.runtime.import=/tmp/test.zip
      And container log should not contain -Ddashbuilder.import.base.dir
-     And container log should not contain set using DASHBUILDER_IMPORTS_BASE_DIR env does not exist, using the default /opt/kie/data/imports
+     And container log should not contain set using DASHBUILDER_IMPORTS_BASE_DIR env does not exist, using the default /opt/kie/dashbuilder/imports
 
   Scenario: Verify if the default value for dashbuilder.import.base.dir is correctly set
     When container is ready
-    Then container log should contain -Ddashbuilder.import.base.dir=/opt/kie/data/imports
-     And container log should not contain set using DASHBUILDER_IMPORTS_BASE_DIR env does not exist, using the default /opt/ki0/datae/imports
+    Then container log should contain -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports
+     And container log should not contain set using DASHBUILDER_IMPORTS_BASE_DIR env does not exist, using the default /opt/kie/dashbuilder/imports
      And container log should not contain -Ddashbuilder.runtime.import
 
   Scenario: Verify if DASHBUILDER_IMPORTS_BASE_DIR is correctly set
@@ -82,9 +82,9 @@ Feature: RHPAM Dashbuilder Runtime configuration tests
     When container is started with env
       | variable                      | value     |
       | DASHBUILDER_IMPORTS_BASE_DIR  | /nonsense |
-    Then container log should contain The directory [/nonsense] set using DASHBUILDER_IMPORTS_BASE_DIR env does not exist, using the default [/opt/kie/data/imports]
-     And container log should contain Dashbuilder file location import dir is /opt/kie/data/imports
-     And container log should contain -Ddashbuilder.import.base.dir=/opt/kie/data/imports
+    Then container log should contain The directory [/nonsense] set using DASHBUILDER_IMPORTS_BASE_DIR env does not exist, using the default [/opt/kie/dashbuilder/imports]
+     And container log should contain Dashbuilder file location import dir is /opt/kie/dashbuilder/imports
+     And container log should contain -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports
 
   Scenario: Verify if DASHBUILDER_MODEL_UPDATE and DASHBUILDER_MODEL_FILE_REMOVAL and DASHBUILDER_RUNTIME_MULTIPLE_IMPORT are correctly set
     When container is started with env
@@ -93,7 +93,7 @@ Feature: RHPAM Dashbuilder Runtime configuration tests
       | DASHBUILDER_MODEL_FILE_REMOVAL      | true   |
       | DASHBUILDER_RUNTIME_MULTIPLE_IMPORT | true   |
     Then container log should not contain dashbuilder.runtime.import
-     And container log should contain -Ddashbuilder.import.base.dir=/opt/kie/data/imports
+     And container log should contain -Ddashbuilder.import.base.dir=/opt/kie/dashbuilder/imports
      And container log should contain -Ddashbuilder.model.update=false
      And container log should contain -Ddashbuilder.removeModelFile=true
      And container log should contain -Ddashbuilder.runtime.multi=true
@@ -107,31 +107,38 @@ Feature: RHPAM Dashbuilder Runtime configuration tests
   Scenario: Verify if external component configuration is correctly set with default values
     When container is started with env
       | variable                | value  |
-      | DASHBUILDER_COMP_ENABLE | true   |
     Then container log should contain -Ddashbuilder.components.enable=true
-     And container log should contain -Ddashbuilder.components.dir=/opt/kie/data/components
-     And container log should not contain set using DASHBUILDER_EXTERNAL_COMP_DIR env does not exist, the default /opt/kie/data/components
+     And container log should contain -Ddashbuilder.components.dir=/opt/kie/dashbuilder/components
+     And container log should not contain set using DASHBUILDER_EXTERNAL_COMP_DIR env does not exist, the default /opt/kie/dashbuilder/components
 
   Scenario: Verify if external component configuration is correctly set with custom directory
     When container is started with env
       | variable                      | value  |
-      | DASHBUILDER_COMP_ENABLE       | true   |
       | DASHBUILDER_EXTERNAL_COMP_DIR | /tmp   |
     Then container log should contain -Ddashbuilder.components.enable=true
      And container log should contain -Ddashbuilder.components.dir=/tmp
      And container log should contain Dashbuilder external component enabled, component dir is /tmp
-     And container log should not contain set using DASHBUILDER_EXTERNAL_COMP_DIR env does not exist, the default /opt/kie/data/components
+     And container log should not contain set using DASHBUILDER_EXTERNAL_COMP_DIR env does not exist, the default /opt/kie/dashbuilder/components
 
   Scenario: Verify if external component configuration is correctly set with invalid custom directory
     When container is started with env
       | variable                      | value     |
-      | DASHBUILDER_COMP_ENABLE       | true      |
       | DASHBUILDER_EXTERNAL_COMP_DIR | /nonsense |
     Then container log should contain -Ddashbuilder.components.enable=true
-     And container log should contain -Ddashbuilder.components.dir=/opt/kie/data/components
-     And container log should contain Dashbuilder external component enabled, component dir is /opt/kie/data/components
-     And container log should contain The directory [/nonsense] set using DASHBUILDER_EXTERNAL_COMP_DIR env does not exist, the default [/opt/kie/data/components]
+     And container log should contain -Ddashbuilder.components.dir=/opt/kie/dashbuilder/components
+     And container log should contain Dashbuilder external component enabled, component dir is /opt/kie/dashbuilder/components
+     And container log should contain The directory [/nonsense] set using DASHBUILDER_EXTERNAL_COMP_DIR env does not exist, the default [/opt/kie/dashbuilder/components]
 
+
+  Scenario: Verify if external component configuration is correctly set with invalid custom directory
+    When container is started with env
+      | variable                      | value     |
+      | DASHBUILDER_COMP_ENABLE       | false     |
+      | DASHBUILDER_EXTERNAL_COMP_DIR | /nonsense |
+    Then container log should contain -Ddashbuilder.components.enable=false
+     And container log should not contain -Ddashbuilder.components.dir=/opt/kie/dashbuilder/components
+     And container log should not contain Dashbuilder external component enabled, component dir is /opt/kie/dashbuilder/components
+     And container log should not contain The directory [/nonsense] set using DASHBUILDER_EXTERNAL_COMP_DIR env does not exist, the default [/opt/kie/dashbuilder/components]
 
   Scenario: Verify if the KIE Server DataSet is correctly configured using credentials
     When container is started with env
@@ -225,3 +232,15 @@ Feature: RHPAM Dashbuilder Runtime configuration tests
      And container log should not contain -Ddashbuilder.kieserver.serverTemplate.ServerTemplateTest.user
      And container log should not contain -Ddashbuilder.kieserver.serverTemplate.ServerTemplateTest.password
 
+  Scenario: Verify if the KIE Server serverTemplate with dash is correctly configured using credentials
+    When container is started with env
+      | variable                      | value                 |
+      | SCRIPT_DEBUG                  | true                  |
+      | KIESERVER_SERVER_TEMPLATES    | server-template-test  |
+      | server_template_test_LOCATION | http://localmoon.com  |
+      | server_template_test_USER     | moon                  |
+      | server_template_test_PASSWORD | sun                   |
+    Then container log should contain -Ddashbuilder.kieserver.serverTemplate.server-template-test.location=http://localmoon.com
+     And container log should contain -Ddashbuilder.kieserver.serverTemplate.server-template-test.replace_query=false
+     And container log should contain -Ddashbuilder.kieserver.serverTemplate.server-template-test.user=moon
+     And container log should contain -Ddashbuilder.kieserver.serverTemplate.server-template-test.password=sun


### PR DESCRIPTION
See: https://issues.redhat.com/browse/RHPAM-3248

Allow script to have serverTemplate and datasetId names with dash
to properly configure kieserver integration with Dashbuilder
automatically.

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
