### PR TITLE
[RHPAM-3364] BusinessCentral pod in authoring-ha deployment won't start with EAP_734_CR2

### DIFF
--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -346,8 +346,8 @@ function configure_ha_common() {
         <replicated-cache name='repl'>\
             <file-store/>\
         </replicated-cache>\
-        <replicated-cache name="sso" mode="SYNC" batching="true"/>\
-        <replicated-cache name="routing"/>\
+        <replicated-cache name='sso'/>\
+        <replicated-cache name='routing'/>\
         <distributed-cache name='dist'>\
             <file-store/>\
         </distributed-cache>"

--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -339,11 +339,15 @@ function configure_ha_common() {
     # step 2) modify the web cache container per https://access.redhat.com/solutions/2776221
     #         note: the below differs from the EAP 7.1 solution above, since EAP 7.2
     #               doesn't have "mode", "l1", and "owners" attributes in the original config
+    # step 3) The lines replicated-cache name="sso" and replicated-cache name="routing"
+    #          are needed to start with eap 7.3.X
     local web_cache="\
         <transport lock-timeout='60000'/>\
         <replicated-cache name='repl'>\
             <file-store/>\
         </replicated-cache>\
+        <replicated-cache name="sso" mode="SYNC" batching="true"/>\
+        <replicated-cache name="routing"/>\
         <distributed-cache name='dist'>\
             <file-store/>\
         </distributed-cache>"


### PR DESCRIPTION
See: https://issues.redhat.com/browse/RHPAM-3364
Signed-off-by: desmax74 <mdessi@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
