### PR TITLE
[KIECLOUD-548] - Adjust permissions on os-eap-sso-adapters module

### DIFF
--- a/os-eap7-sso-adapters/configure.sh
+++ b/os-eap7-sso-adapters/configure.sh
@@ -7,5 +7,8 @@ SOURCES_DIR="/tmp/artifacts"
 unzip -o "$SOURCES_DIR"/rh-sso-7.4.5-eap7-adapter.zip -d $JBOSS_HOME
 unzip -o "$SOURCES_DIR"/rh-sso-7.4.5-saml-eap7-adapter.zip -d $JBOSS_HOME
 
-chown -R jboss:root $JBOSS_HOME
-chmod -R g+rwX $JBOSS_HOME
+for dir in $JBOSS_HOME/docs/licenses-rh-sso $JBOSS_HOME/modules/system/add-ons $JBOSS_HOME/bin; do
+    chown -R jboss:root $dir
+    chmod -R g+rwX $dir
+done
+


### PR DESCRIPTION
Signed-off-by: spolti <fspolti@redhat.com>
See: https://issues.redhat.com/browse/KIECLOUD-548

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
