### PR TITLE
[RHPAM-3805] - Missing kie dependencies in Kie Server ocp image

### DIFF
--- a/jboss-kie-kieserver/configure.sh
+++ b/jboss-kie-kieserver/configure.sh
@@ -53,15 +53,7 @@ for dir in /deployments $JBOSS_HOME $HOME; do
     chmod -R g+rwX $dir
 done
 
-# Dir for optional deps
-mkdir -p /opt/kie/dependencies/jbpm-clustering
-chown -R jboss:root /opt/kie/dependencies/jbpm-clustering
-chmod -R 755 /opt/kie/dependencies/jbpm-clustering
-
 # Create dir to remove JDBC driver
 mkdir ${JBOSS_HOME}/modules/system/layers/openshift 2&> /dev/null || true
 chown -R jboss:root ${JBOSS_HOME}/modules/system/layers/openshift
 
-mkdir -p /opt/kie/dependencies/jbpm-kafka
-chown -R jboss:root /opt/kie/dependencies/jbpm-kafka
-chmod -R 755 /opt/kie/dependencies/jbpm-kafka


### PR DESCRIPTION
Signed-off-by: spolti <fspolti@redhat.com>
See: https://issues.redhat.com/browse/RHPAM-3805

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
