### PR TITLE
[KIECLOUD-566] - Permission issues on standalone dir on workbench and…

### DIFF
--- a/jboss-kie-dashbuilder/configure.sh
+++ b/jboss-kie-dashbuilder/configure.sh
@@ -14,6 +14,8 @@ chmod ug+x ${JBOSS_HOME}/bin/openshift-launch.sh
 mkdir -p /opt/kie/dashbuilder/{imports,components}
 chown -R jboss:root /opt/kie
 
-# Set bin permissions
-chown -R jboss:root ${JBOSS_HOME}/bin/
-chmod -R g+rwX ${JBOSS_HOME}/bin/
+# Necessary to permit running with a randomised UID
+for dir in $JBOSS_HOME/bin /opt/kie; do
+    chown -R jboss:root $dir
+    chmod -R g+rwX $dir
+done

--- a/jboss-kie-workbench/configure.sh
+++ b/jboss-kie-workbench/configure.sh
@@ -11,18 +11,13 @@ mkdir -p ${JBOSS_HOME}/bin/launch
 cp -r ${ADDED_DIR}/launch/* ${JBOSS_HOME}/bin/launch
 chmod ug+x ${JBOSS_HOME}/bin/openshift-launch.sh
 
-# Set bin permissions
-chown -R jboss:root ${JBOSS_HOME}/bin/
-chmod -R g+rwX ${JBOSS_HOME}/bin/
-
-# Ensure that the local data directory exists
-DATA_DIR=${JBOSS_HOME}/standalone/data
+# /opt/kie directory
 KIE_HOME_DIR=/opt/kie
-mkdir -p ${DATA_DIR}
 mkdir -p ${KIE_HOME_DIR}
+
 # Necessary to permit running with a randomised UID
-chown -R jboss:root ${DATA_DIR}
-chmod -R 0755 ${DATA_DIR}
-chown -R jboss:root ${KIE_HOME_DIR}
-chmod -R 0755 ${KIE_HOME_DIR}
+for dir in $JBOSS_HOME/bin $HOME $KIE_HOME_DIR; do
+    chown -R jboss:root $dir
+    chmod -R g+rwX $dir
+done
 


### PR DESCRIPTION
… dashbuilder images
See: https://issues.redhat.com/browse/KIECLOUD-566

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
