### PR TITLE
Fix python: command not found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           name: install dependencies
           command: |
             sudo apt-get install libxml2-utils maven
+            sudo ln -s /usr/bin/python3 /usr/bin/python
       - run:
           type: shell
           name: install bats-core

--- a/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver-jms.bats
+++ b/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver-jms.bats
@@ -25,16 +25,18 @@ teardown() {
 }
 
 @test "test default request/response queue values on META-INF/kie-server-jms.xml file" {
-    expected_jms_queue_name=" name=\"KIE.SERVER.REQUEST\" name=\"KIE.SERVER.RESPONSE\" name=\"KIE.SERVER.EXECUTOR\""
-    expected_entry_name="<entry name=\"queue/KIE.SERVER.REQUEST\"/><entry name=\"queue/KIE.SERVER.RESPONSE\"/><entry name=\"queue/KIE.SERVER.EXECUTOR\"/>"
+    expected_jms_queue_name='name="KIE.SERVER.REQUEST" name="KIE.SERVER.RESPONSE" name="KIE.SERVER.EXECUTOR"'
+    expected_entry_name='<entry name="queue/KIE.SERVER.REQUEST"/> <entry name="queue/KIE.SERVER.RESPONSE"/> <entry name="queue/KIE.SERVER.EXECUTOR"/>'
+
     run configure
-    result_entry_name=$(xmllint --xpath "//*[local-name()='jms-queue']//*[local-name()='entry']"[1] ${KIE_JMS_FILE})
-    result_jms_queue_name=$(xmllint --xpath "//*[local-name()='jms-queue']/@name" ${KIE_JMS_FILE})
-    echo "Expected: ${result_entry_name}"
-    echo "Result: ${expected_entry_name}"
+    result_entry_name=`echo -e $(xmllint --xpath "//*[local-name()='jms-queue']//*[local-name()='entry']"[1] ${KIE_JMS_FILE})`
+    result_jms_queue_name=`echo -e $(xmllint --xpath "//*[local-name()='jms-queue']/@name" ${KIE_JMS_FILE})`
+
+    echo "Result  : ${result_entry_name}"
+    echo "Expected: ${expected_entry_name}"
     [ "${result_entry_name}" = "${expected_entry_name}" ]
+    echo "Result  : ${result_jms_queue_name}"
     echo "Expected: ${expected_jms_queue_name}"
-    echo "Result: ${result_jms_queue_name}"
     [ "${result_jms_queue_name}" = "${expected_jms_queue_name}" ]
 }
 
@@ -42,22 +44,22 @@ teardown() {
     KIE_SERVER_JMS_QUEUE_REQUEST="queue/MY.KIE.SERVER.REQUEST"
     KIE_SERVER_JMS_QUEUE_RESPONSE="queue/MY.KIE.SERVER.RESPONSE"
     KIE_SERVER_JMS_QUEUE_EXECUTOR="queue/MY.KIE.SERVER.EXECUTOR"
-    expected_jms_queue_name=" name=\"MY.KIE.SERVER.REQUEST\" name=\"MY.KIE.SERVER.RESPONSE\" name=\"MY.KIE.SERVER.EXECUTOR\""
-    expected_entry_name="<entry name=\"queue/MY.KIE.SERVER.REQUEST\"/><entry name=\"java:jboss/exported/jms/queue/MY.KIE.SERVER.REQUEST\"/><entry name=\"queue/MY.KIE.SERVER.RESPONSE\"/><entry name=\"java:jboss/exported/jms/queue/MY.KIE.SERVER.RESPONSE\"/><entry name=\"queue/MY.KIE.SERVER.EXECUTOR\"/>"
+    expected_jms_queue_name=' name="MY.KIE.SERVER.REQUEST" name="MY.KIE.SERVER.RESPONSE" name="MY.KIE.SERVER.EXECUTOR"'
+    expected_entry_name='<entry name="queue/MY.KIE.SERVER.REQUEST"/> <entry name="java:jboss/exported/jms/queue/MY.KIE.SERVER.REQUEST"/> <entry name="queue/MY.KIE.SERVER.RESPONSE"/> <entry name="java:jboss/exported/jms/queue/MY.KIE.SERVER.RESPONSE"/> <entry name="queue/MY.KIE.SERVER.EXECUTOR"/>'
     run configure
-    result_entry_name=$(xmllint --xpath "//*[local-name()='jms-queue']//*[local-name()='entry']" ${KIE_JMS_FILE})
-    result_jms_queue_name=$(xmllint --xpath "//*[local-name()='jms-queue']/@name" ${KIE_JMS_FILE})
+    result_entry_name=`echo -e $(xmllint --xpath "//*[local-name()='jms-queue']//*[local-name()='entry']" ${KIE_JMS_FILE})`
+    result_jms_queue_name=`echo -e  $(xmllint --xpath "//*[local-name()='jms-queue']/@name" ${KIE_JMS_FILE})`
     echo "Expected: ${expected_entry_name}"
-    echo "Result: ${result_entry_name}"
+    echo "Result  : ${result_entry_name}"
     [ "${result_entry_name}" = "${expected_entry_name}" ]
 }
 
 @test "test default request/executor queue values on WEB-INF/ejb-jar.xml file" {
-    expected="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value>"
+    expected="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value>"
     run configure
-    result=$(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})
+    result=`echo -e $(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})`
     echo "Expected: ${expected}"
-    echo "Result: ${result}"
+    echo "Result  : ${result}"
     [ "${result}" = "${expected}" ]
 }
 
@@ -65,11 +67,11 @@ teardown() {
     KIE_SERVER_JMS_QUEUE_REQUEST="queue/MY.KIE.SERVER.REQUEST"
     KIE_SERVER_JMS_QUEUE_RESPONSE="queue/MY.KIE.SERVER.RESPONSE"
     KIE_SERVER_JMS_QUEUE_EXECUTOR="queue/MY.KIE.SERVER.EXECUTOR"
-    expected="<activation-config-property-value>queue/MY.KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>queue/MY.KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>queue/MY.KIE.SERVER.EXECUTOR</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value>"
+    expected="<activation-config-property-value>queue/MY.KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>queue/MY.KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>queue/MY.KIE.SERVER.EXECUTOR</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value>"
     run configure
-    result=$(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})
+    result=`echo -e $(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})`
     echo "Expected: ${expected}"
-    echo "Result: ${result}"
+    echo "Result  : ${result}"
     [ "${result}" = "${expected}" ]
 }
 
@@ -85,9 +87,9 @@ teardown() {
 
 @test "test default signal queue configuration kie-jms-file" {
     KIE_SERVER_JMS_ENABLE_SIGNAL="true"
-    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/><entry name="queue/KIE.SERVER.RESPONSE"/><entry name="queue/KIE.SERVER.EXECUTOR"/><entry name="queue/KIE.SERVER.SIGNAL"/>'
+    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/> <entry name="queue/KIE.SERVER.RESPONSE"/> <entry name="queue/KIE.SERVER.EXECUTOR"/> <entry name="queue/KIE.SERVER.SIGNAL"/>'
     run configureJmsSignal
-    result_kie_jms_xml=$(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})
+    result_kie_jms_xml=`echo -e $(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})`
     echo "Expected kie jms file: ${expected_kie_jms_xml}"
     echo "Result kie jms file: ${result_kie_jms_xml}"
     [ "${result_kie_jms_xml}" = "${expected_kie_jms_xml}" ]
@@ -96,9 +98,9 @@ teardown() {
 @test "test custom signal queue configuration kie-jms-file" {
     KIE_SERVER_JMS_ENABLE_SIGNAL="true"
     KIE_SERVER_JMS_QUEUE_SIGNAL="queue/CUSTOM.SIGNAL.QUEUE"
-    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/><entry name="queue/KIE.SERVER.RESPONSE"/><entry name="queue/KIE.SERVER.EXECUTOR"/><entry name="queue/CUSTOM.SIGNAL.QUEUE"/>'
+    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/> <entry name="queue/KIE.SERVER.RESPONSE"/> <entry name="queue/KIE.SERVER.EXECUTOR"/> <entry name="queue/CUSTOM.SIGNAL.QUEUE"/>'
     run configureJmsSignal
-    result_kie_jms_xml=$(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})
+    result_kie_jms_xml=`echo -e $(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})`
     echo "Expected kie jms file: ${expected_kie_jms_xml}"
     echo "Result kie jms file: ${result_kie_jms_xml}"
     [ "${result_kie_jms_xml}" = "${expected_kie_jms_xml}" ]
@@ -106,30 +108,30 @@ teardown() {
 
 @test "test default signal queue configuration ejb-jar" {
     KIE_SERVER_JMS_ENABLE_SIGNAL="true"
-    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>java:/queue/KIE.SERVER.SIGNAL</activation-config-property-value>"
+    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>java:/queue/KIE.SERVER.SIGNAL</activation-config-property-value>"
     run configureJmsSignal
-    result_ejb_jar=$(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})
+    result_ejb_jar=`echo -e $(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})`
     echo "Expected ejb jar: ${expected_ejb_jar}"
-    echo "Result ejb jar: ${result_ejb_jar}"
+    echo "Result ejb jar  : ${result_ejb_jar}"
     [ "${result_ejb_jar}" = "${expected_ejb_jar}" ]
 }
 
 @test "test custom signal queue configuration ejb-jar" {
     KIE_SERVER_JMS_ENABLE_SIGNAL="true"
     KIE_SERVER_JMS_QUEUE_SIGNAL="queue/CUSTOM.SIGNAL.QUEUE"
-    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>java:/queue/CUSTOM.SIGNAL.QUEUE</activation-config-property-value>"
+    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>java:/queue/CUSTOM.SIGNAL.QUEUE</activation-config-property-value>"
     run configureJmsSignal
-    result_ejb_jar=$(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})
+    result_ejb_jar=`echo -e $(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})`
     echo "Expected ejb jar: ${expected_ejb_jar}"
-    echo "Result ejb jar: ${result_ejb_jar}"
+    echo "Result ejb jar  : ${result_ejb_jar}"
     [ "${result_ejb_jar}" = "${expected_ejb_jar}" ]
 }
 
 @test "test default audit queue configuration kie-jms-file" {
     KIE_SERVER_JMS_ENABLE_AUDIT="true"
-    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/><entry name="queue/KIE.SERVER.RESPONSE"/><entry name="queue/KIE.SERVER.EXECUTOR"/><entry name="queue/KIE.SERVER.AUDIT"/>'
+    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/> <entry name="queue/KIE.SERVER.RESPONSE"/> <entry name="queue/KIE.SERVER.EXECUTOR"/> <entry name="queue/KIE.SERVER.AUDIT"/>'
     run configureJmsAudit
-    result_kie_jms_xml=$(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})
+    result_kie_jms_xml=`echo -e $(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})`
     echo "Expected kie jms file: ${expected_kie_jms_xml}"
     echo "Result kie jms file: ${result_kie_jms_xml}"
     [ "${result_kie_jms_xml}" = "${expected_kie_jms_xml}" ]
@@ -138,9 +140,9 @@ teardown() {
 @test "test custom audit queue configuration kie-jms-file" {
     KIE_SERVER_JMS_ENABLE_AUDIT="true"
     KIE_SERVER_JMS_QUEUE_AUDIT="queue/CUSTOM.AUDIT.QUEUE"
-    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/><entry name="queue/KIE.SERVER.RESPONSE"/><entry name="queue/KIE.SERVER.EXECUTOR"/><entry name="queue/CUSTOM.AUDIT.QUEUE"/>'
+    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/> <entry name="queue/KIE.SERVER.RESPONSE"/> <entry name="queue/KIE.SERVER.EXECUTOR"/> <entry name="queue/CUSTOM.AUDIT.QUEUE"/>'
     run configureJmsAudit
-    result_kie_jms_xml=$(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})
+    result_kie_jms_xml=`echo -e $(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})`
     echo "Expected kie jms file: ${expected_kie_jms_xml}"
     echo "Result kie jms file: ${result_kie_jms_xml}"
     [ "${result_kie_jms_xml}" = "${expected_kie_jms_xml}" ]
@@ -148,9 +150,9 @@ teardown() {
 
 @test "test default audit queue configuration ejb-jar" {
     KIE_SERVER_JMS_ENABLE_AUDIT="true"
-    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>java:/queue/KIE.SERVER.AUDIT</activation-config-property-value><activation-config-property-value>1</activation-config-property-value>"
+    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>java:/queue/KIE.SERVER.AUDIT</activation-config-property-value> <activation-config-property-value>1</activation-config-property-value>"
     run configureJmsAudit
-    result_ejb_jar=$(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})
+    result_ejb_jar=`echo -e $(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})`
     echo "Expected ejb jar: ${expected_ejb_jar}"
     echo "Result ejb jar: ${result_ejb_jar}"
     [ "${result_ejb_jar}" = "${expected_ejb_jar}" ]
@@ -159,9 +161,9 @@ teardown() {
 @test "test custom audit queue configuration ejb-jar" {
     KIE_SERVER_JMS_ENABLE_AUDIT="true"
     KIE_SERVER_JMS_QUEUE_AUDIT="queue/CUSTOM.AUDIT.QUEUE"
-    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>java:/queue/CUSTOM.AUDIT.QUEUE</activation-config-property-value><activation-config-property-value>1</activation-config-property-value>"
+    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>java:/queue/CUSTOM.AUDIT.QUEUE</activation-config-property-value> <activation-config-property-value>1</activation-config-property-value>"
     run configureJmsAudit
-    result_ejb_jar=$(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})
+    result_ejb_jar=`echo -e $(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})`
     echo "Expected ejb jar: ${expected_ejb_jar}"
     echo "Result ejb jar: ${result_ejb_jar}"
     [ "${result_ejb_jar}" = "${expected_ejb_jar}" ]
@@ -172,16 +174,16 @@ teardown() {
     KIE_SERVER_JMS_ENABLE_SIGNAL="true"
     run configureJmsAudit
     run configureJmsSignal
-    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/><entry name="queue/KIE.SERVER.RESPONSE"/><entry name="queue/KIE.SERVER.EXECUTOR"/><entry name="queue/KIE.SERVER.SIGNAL"/><entry name="queue/KIE.SERVER.AUDIT"/>'
-    result_kie_jms_xml=$(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})
+    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/> <entry name="queue/KIE.SERVER.RESPONSE"/> <entry name="queue/KIE.SERVER.EXECUTOR"/> <entry name="queue/KIE.SERVER.SIGNAL"/> <entry name="queue/KIE.SERVER.AUDIT"/>'
+    result_kie_jms_xml=`echo -e $(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})`
     echo "Expected kie jms file: ${expected_kie_jms_xml}"
-    echo "Result kie jms file: ${result_kie_jms_xml}"
+    echo "Result kie jms file  : ${result_kie_jms_xml}"
     [ "${result_kie_jms_xml}" = "${expected_kie_jms_xml}" ]
 
-    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>java:/queue/KIE.SERVER.SIGNAL</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>java:/queue/KIE.SERVER.AUDIT</activation-config-property-value><activation-config-property-value>1</activation-config-property-value>"
-    result_ejb_jar=$(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})
+    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>java:/queue/KIE.SERVER.SIGNAL</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>java:/queue/KIE.SERVER.AUDIT</activation-config-property-value> <activation-config-property-value>1</activation-config-property-value>"
+    result_ejb_jar=`echo -e $(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})`
     echo "Expected ejb jar: ${expected_ejb_jar}"
-    echo "Result ejb jar: ${result_ejb_jar}"
+    echo "Result ejb jar  : ${result_ejb_jar}"
     [ "${result_ejb_jar}" = "${expected_ejb_jar}" ]
 }
 
@@ -193,14 +195,14 @@ teardown() {
     run configureJmsAudit
     run configureJmsSignal
 
-    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/><entry name="queue/KIE.SERVER.RESPONSE"/><entry name="queue/KIE.SERVER.EXECUTOR"/><entry name="queue/CUSTOM.SIGNAL.QUEUE"/><entry name="queue/CUSTOM.AUDIT.QUEUE"/>'
-    result_kie_jms_xml=$(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})
+    expected_kie_jms_xml='<entry name="queue/KIE.SERVER.REQUEST"/> <entry name="queue/KIE.SERVER.RESPONSE"/> <entry name="queue/KIE.SERVER.EXECUTOR"/> <entry name="queue/CUSTOM.SIGNAL.QUEUE"/> <entry name="queue/CUSTOM.AUDIT.QUEUE"/>'
+    result_kie_jms_xml=`echo -e $(xmllint --xpath "//*[local-name()='jms-queue']/*[local-name()='entry']"[1] ${KIE_JMS_FILE})`
     echo "Expected kie jms file: ${expected_kie_jms_xml}"
     echo "Result kie jms file: ${result_kie_jms_xml}"
     [ "${result_kie_jms_xml}" = "${expected_kie_jms_xml}" ]
 
-    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>Auto-acknowledge</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>java:/queue/CUSTOM.SIGNAL.QUEUE</activation-config-property-value><activation-config-property-value>javax.jms.Queue</activation-config-property-value><activation-config-property-value>java:/queue/CUSTOM.AUDIT.QUEUE</activation-config-property-value><activation-config-property-value>1</activation-config-property-value>"
-    result_ejb_jar=$(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})
+    expected_ejb_jar="<activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.REQUEST</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>queue/KIE.SERVER.EXECUTOR</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>Auto-acknowledge</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>java:/queue/CUSTOM.SIGNAL.QUEUE</activation-config-property-value> <activation-config-property-value>javax.jms.Queue</activation-config-property-value> <activation-config-property-value>java:/queue/CUSTOM.AUDIT.QUEUE</activation-config-property-value> <activation-config-property-value>1</activation-config-property-value>"
+    result_ejb_jar=`echo -e $(xmllint --xpath "//*[local-name()='activation-config-property-value']" ${KIE_EJB_JAR_FILE})`
     echo "Expected ejb jar: ${expected_ejb_jar}"
     echo "Result ejb jar: ${result_ejb_jar}"
     [ "${result_ejb_jar}" = "${expected_ejb_jar}" ]


### PR DESCRIPTION
Apprently the CircleCI has changed the the buildpack image and
the python command is not available anymore, a alias should handle it.

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
