### PR TITLE
[KIECLOUD-576] - RHDM KIE Server image: /opt/kie directory not found

### DIFF
--- a/jboss-kie-kieserver/configure.sh
+++ b/jboss-kie-kieserver/configure.sh
@@ -48,6 +48,7 @@ chmod -R 755 ${KIE_DIR}
 
 # /opt/kie directory
 KIE_HOME_DIR=/opt/kie
+mkdir -p ${KIE_HOME_DIR}
 
 # Necessary to permit running with a randomised UID
 for dir in $JBOSS_HOME/bin $HOME $KIE_HOME_DIR; do


### PR DESCRIPTION
Signed-off-by: spolti <fspolti@redhat.com>
See: https://issues.redhat.com/browse/KIECLOUD-576

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
