### PR TITLE
[KIECLOUD-597] - XA datasource URL property is set even if no URL is …

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -332,8 +332,10 @@ function declare_xa_variables {
                 eval ${prefix}_XA_CONNECTION_PROPERTY_ServerName=${host}
                 eval ${prefix}_XA_CONNECTION_PROPERTY_PortNumber=${port}
 
-            else
+            elif [ "${host}x" != "x" ] || [ "${port}x" != "x" ]; then
                 eval ${prefix}_XA_CONNECTION_PROPERTY_URL="${jdbcUrl}"
+            else
+                eval unset ${prefix}_XA_CONNECTION_PROPERTY_URL
             fi
         fi
 
@@ -373,7 +375,7 @@ function declare_xa_variables {
         fi
 
     elif [ "x${url}" != "x" ]; then
-            # RHPAM-2261 - db2 does not accept URL/Url XA property
+        # RHPAM-2261 - db2 does not accept URL/Url XA property
         if [[ $EJB_TIMER_DRIVER = *"db2"* ]]; then
             local unprefixedUrl=${url#jdbc:db2://}
             local serverName=${unprefixedUrl%:*}

--- a/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
+++ b/jboss-kie-kieserver/tests/bats/jboss-kie-kieserver.bats
@@ -455,6 +455,7 @@ teardown() {
     [ "${EJB_TIMER_XA_CONNECTION_PROPERTY_PortNumber}" = "${RHPAM_SERVICE_PORT}" ]
     # the URL property must not be set
     [ "${EJB_TIMER_XA_CONNECTION_PROPERTY_URL}" = "" ]
+    [ "${RHPAM_XA_CONNECTION_PROPERTY_URL}" = "" ]
 }
 
 @test "verify if EJB_TIMER is correctly configured with with Oracle HA jdbc URL" {

--- a/tests/features/rhpam/rhpam-kieserver.feature
+++ b/tests/features/rhpam/rhpam-kieserver.feature
@@ -231,6 +231,7 @@ Feature: RHPAM KIE Server configuration tests
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='validation']/*[local-name()='background-validation']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker on XPath //*[local-name()='validation']/*[local-name()='valid-connection-checker']/@class-name
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter on XPath //*[local-name()='validation']/*[local-name()='exception-sorter']/@class-name
+     And file /opt/eap/standalone/configuration/standalone-openshift.xml should not contain value jdbc:postgresql://:/
      And container log should not contain WARN Missing configuration for XA datasource EJB_TIMER
 
 


### PR DESCRIPTION
…provided
See: https://issues.redhat.com/browse/KIECLOUD-597

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
