### PR TITLE
[RHPAM-4132] - OpenShift images ignore LDAP roles when is set defautl…

### DIFF
--- a/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-elytron.sh
+++ b/jboss-kie-wildfly-common/added/launch/jboss-kie-wildfly-elytron.sh
@@ -303,10 +303,15 @@ function configure_ldap_sec_domain() {
     if [ "${AUTH_LDAP_URL}x" != "x" ]; then
         local sec_domain_default_role=""
         if [ "${AUTH_LDAP_DEFAULT_ROLE}x" != "x" ]; then
-            sec_domain_default_role="role-mapper=\"kie-ldap-role-mapper\" "
+            sec_domain_default_role="role-mapper=\"kie-ldap-logical-default-role-mapper\""
             local default_role="<constant-role-mapper name=\"kie-ldap-role-mapper\">\n\
                     <role name=\"${AUTH_LDAP_DEFAULT_ROLE}\"/>\n\
-                </constant-role-mapper>"
+                </constant-role-mapper>\n\
+                <mapped-role-mapper name=\"kie-ldap-mapped-roles\" keep-mapped=\"true\" keep-non-mapped=\"true\">\n\
+                    <role-mapping from=\"${AUTH_LDAP_DEFAULT_ROLE}\" to=\"${AUTH_LDAP_DEFAULT_ROLE}\"/>\n\
+                </mapped-role-mapper>\n\
+                <logical-role-mapper name=\"kie-ldap-logical-default-role-mapper\" logical-operation=\"or\" left=\"kie-ldap-mapped-roles\" right=\"kie-ldap-role-mapper\"/>"
+
             sed -i "s|<!-- ##KIE_AUTH_LDAP_DEFAULT_ROLE## -->|${default_role}|" $CONFIG_FILE
         fi
 
@@ -314,8 +319,8 @@ function configure_ldap_sec_domain() {
         if [ "${AUTH_LDAP_LOGIN_FAILOVER^^}" == "TRUE" ] || [ "${AUTH_LDAP_LOGIN_MODULE}" == "optional" ]; then
             role_decoder="kie-aggregate-role-decoder"
         fi
-        local sec_domain="<security-domain name=\"$(get_security_domain)\" default-realm=\"$(get_ldap_realm)\" ${sec_domain_default_role}permission-mapper=\"default-permission-mapper\">\n\
-                    <realm name=\"$(get_ldap_realm)\" role-decoder=\"${role_decoder}\"/>\n\
+        local sec_domain="<security-domain name=\"$(get_security_domain)\" default-realm=\"$(get_ldap_realm)\" permission-mapper=\"default-permission-mapper\">\n\
+                    <realm name=\"$(get_ldap_realm)\" role-decoder=\"${role_decoder}\" ${sec_domain_default_role}/>\n\
                 </security-domain>"
         sed -i "s|<!-- ##KIE_LDAP_SECURITY_DOMAIN## -->|${sec_domain}|" $CONFIG_FILE
     fi

--- a/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-elytron.bats
+++ b/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-elytron.bats
@@ -595,8 +595,8 @@ teardown() {
 
     configure_ldap_sec_domain
 
-    expected="<security-domain name=\"KIELdapSecurityDomain\" default-realm=\"KIELdapRealm\" role-mapper=\"kie-ldap-role-mapper\" permission-mapper=\"default-permission-mapper\">
-                    <realm name=\"KIELdapRealm\" role-decoder=\"from-roles-attribute\"/>
+    expected="<security-domain name=\"KIELdapSecurityDomain\" default-realm=\"KIELdapRealm\" permission-mapper=\"default-permission-mapper\">
+                    <realm name=\"KIELdapRealm\" role-decoder=\"from-roles-attribute\" role-mapper=\"kie-ldap-logical-default-role-mapper\"/>
                 </security-domain>"
     result="$(xmllint --xpath "//*[local-name()='security-domain'][3]" $CONFIG_FILE)"
 
@@ -605,6 +605,14 @@ teardown() {
                 </constant-role-mapper>"
     default_map_role_result="$(xmllint --xpath "//*[local-name()='constant-role-mapper'][2]" $CONFIG_FILE)"
 
+    expected_mapped_role_mapper="<mapped-role-mapper name=\"kie-ldap-mapped-roles\" keep-mapped=\"true\" keep-non-mapped=\"true\">
+                    <role-mapping from=\"${AUTH_LDAP_DEFAULT_ROLE}\" to=\"${AUTH_LDAP_DEFAULT_ROLE}\"/>
+                </mapped-role-mapper>"
+    result_mapped_role_mapper="$(xmllint --xpath "//*[local-name()='mapped-role-mapper']" $CONFIG_FILE)"
+
+    expected_logical_role_mapper="<logical-role-mapper name=\"kie-ldap-logical-default-role-mapper\" logical-operation=\"or\" left=\"kie-ldap-mapped-roles\" right=\"kie-ldap-role-mapper\"/>"
+    result_logical_role_mapper="$(xmllint --xpath "//*[local-name()='logical-role-mapper']" $CONFIG_FILE)"
+
     echo "expected: ${expected}"
     echo "result  : ${result}"
     [ "${expected}" = "${result}" ]
@@ -612,6 +620,14 @@ teardown() {
     echo "default_map_role_expected: ${default_map_role_expected}"
     echo "default_map_role_result  : ${default_map_role_result}"
     [ "${default_map_role_expected}" = "${default_map_role_result}" ]
+
+    echo "expected_mapped_role_mapper: ${expected_mapped_role_mapper}"
+    echo "result_mapped_role_mapper  : ${result_mapped_role_mapper}"
+    [ "${expected_mapped_role_mapper}" = "${result_mapped_role_mapper}" ]
+
+     echo "expected_logical_role_mapper: ${expected_logical_role_mapper}"
+     echo "result_logical_role_mapper  : ${result_logical_role_mapper}"
+     [ "${expected_logical_role_mapper}" = "${result_logical_role_mapper}" ]
 }
 
 
@@ -622,8 +638,8 @@ teardown() {
 
     configure_ldap_sec_domain
 
-    expected="<security-domain name=\"KIELdapWithFailOverSecDomain\" default-realm=\"KIEFailOverRealm\" role-mapper=\"kie-ldap-role-mapper\" permission-mapper=\"default-permission-mapper\">
-                    <realm name=\"KIEFailOverRealm\" role-decoder=\"kie-aggregate-role-decoder\"/>
+    expected="<security-domain name=\"KIELdapWithFailOverSecDomain\" default-realm=\"KIEFailOverRealm\" permission-mapper=\"default-permission-mapper\">
+                    <realm name=\"KIEFailOverRealm\" role-decoder=\"kie-aggregate-role-decoder\" role-mapper=\"kie-ldap-logical-default-role-mapper\"/>
                 </security-domain>"
     result="$(xmllint --xpath "//*[local-name()='security-domain'][3]" $CONFIG_FILE)"
 
@@ -632,6 +648,14 @@ teardown() {
                 </constant-role-mapper>"
     default_map_role_result="$(xmllint --xpath "//*[local-name()='constant-role-mapper'][2]" $CONFIG_FILE)"
 
+    expected_mapped_role_mapper="<mapped-role-mapper name=\"kie-ldap-mapped-roles\" keep-mapped=\"true\" keep-non-mapped=\"true\">
+                    <role-mapping from=\"${AUTH_LDAP_DEFAULT_ROLE}\" to=\"${AUTH_LDAP_DEFAULT_ROLE}\"/>
+                </mapped-role-mapper>"
+    result_mapped_role_mapper="$(xmllint --xpath "//*[local-name()='mapped-role-mapper']" $CONFIG_FILE)"
+
+    expected_logical_role_mapper="<logical-role-mapper name=\"kie-ldap-logical-default-role-mapper\" logical-operation=\"or\" left=\"kie-ldap-mapped-roles\" right=\"kie-ldap-role-mapper\"/>"
+    result_logical_role_mapper="$(xmllint --xpath "//*[local-name()='logical-role-mapper']" $CONFIG_FILE)"
+
     echo "expected: ${expected}"
     echo "result  : ${result}"
     [ "${expected}" = "${result}" ]
@@ -639,6 +663,14 @@ teardown() {
     echo "default_map_role_expected: ${default_map_role_expected}"
     echo "default_map_role_result  : ${default_map_role_result}"
     [ "${default_map_role_expected}" = "${default_map_role_result}" ]
+
+    echo "expected_mapped_role_mapper: ${expected_mapped_role_mapper}"
+    echo "result_mapped_role_mapper  : ${result_mapped_role_mapper}"
+    [ "${expected_mapped_role_mapper}" = "${result_mapped_role_mapper}" ]
+
+     echo "expected_logical_role_mapper: ${expected_logical_role_mapper}"
+     echo "result_logical_role_mapper  : ${result_logical_role_mapper}"
+     [ "${expected_logical_role_mapper}" = "${result_logical_role_mapper}" ]
 }
 
 
@@ -649,8 +681,8 @@ teardown() {
 
     configure_ldap_sec_domain
 
-    expected="<security-domain name=\"KIELdapSecurityDomain\" default-realm=\"KIEDistributedRealm\" role-mapper=\"kie-ldap-role-mapper\" permission-mapper=\"default-permission-mapper\">
-                    <realm name=\"KIEDistributedRealm\" role-decoder=\"kie-aggregate-role-decoder\"/>
+    expected="<security-domain name=\"KIELdapSecurityDomain\" default-realm=\"KIEDistributedRealm\" permission-mapper=\"default-permission-mapper\">
+                    <realm name=\"KIEDistributedRealm\" role-decoder=\"kie-aggregate-role-decoder\" role-mapper=\"kie-ldap-logical-default-role-mapper\"/>
                 </security-domain>"
     result="$(xmllint --xpath "//*[local-name()='security-domain'][3]" $CONFIG_FILE)"
 
@@ -659,6 +691,14 @@ teardown() {
                 </constant-role-mapper>"
     default_map_role_result="$(xmllint --xpath "//*[local-name()='constant-role-mapper'][2]" $CONFIG_FILE)"
 
+    expected_mapped_role_mapper="<mapped-role-mapper name=\"kie-ldap-mapped-roles\" keep-mapped=\"true\" keep-non-mapped=\"true\">
+                    <role-mapping from=\"${AUTH_LDAP_DEFAULT_ROLE}\" to=\"${AUTH_LDAP_DEFAULT_ROLE}\"/>
+                </mapped-role-mapper>"
+    result_mapped_role_mapper="$(xmllint --xpath "//*[local-name()='mapped-role-mapper']" $CONFIG_FILE)"
+
+    expected_logical_role_mapper="<logical-role-mapper name=\"kie-ldap-logical-default-role-mapper\" logical-operation=\"or\" left=\"kie-ldap-mapped-roles\" right=\"kie-ldap-role-mapper\"/>"
+    result_logical_role_mapper="$(xmllint --xpath "//*[local-name()='logical-role-mapper']" $CONFIG_FILE)"
+
     echo "expected: ${expected}"
     echo "result  : ${result}"
     [ "${expected}" = "${result}" ]
@@ -666,6 +706,14 @@ teardown() {
     echo "default_map_role_expected: ${default_map_role_expected}"
     echo "default_map_role_result  : ${default_map_role_result}"
     [ "${default_map_role_expected}" = "${default_map_role_result}" ]
+
+    echo "expected_mapped_role_mapper: ${expected_mapped_role_mapper}"
+    echo "result_mapped_role_mapper  : ${result_mapped_role_mapper}"
+    [ "${expected_mapped_role_mapper}" = "${result_mapped_role_mapper}" ]
+
+     echo "expected_logical_role_mapper: ${expected_logical_role_mapper}"
+     echo "result_logical_role_mapper  : ${result_logical_role_mapper}"
+     [ "${expected_logical_role_mapper}" = "${result_logical_role_mapper}" ]
 }
 
 

--- a/tests/features/common/kie-common.feature
+++ b/tests/features/common/kie-common.feature
@@ -45,7 +45,8 @@ Feature: RHPAM and RHDM common tests
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <attribute from="cn" to="Roles" filter="(member={1})" filter-base-dn="ou=Roles,dc=example,dc=com"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <ldap-realm name="KIELdapRealm" dir-context="KIELdapDC">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <identity-mapping rdn-identifier="uid" search-base-dn="ou=Users,dc=example,dc=com">
-    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" role-mapper="kie-ldap-role-mapper" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <realm name="KIELdapRealm" role-decoder="from-roles-attribute" role-mapper="kie-ldap-logical-default-role-mapper"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security elytron-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <application-security-domain name="other" security-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <constant-role-mapper name="kie-ldap-role-mapper">
@@ -71,7 +72,8 @@ Feature: RHPAM and RHDM common tests
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <attribute from="cn" to="Roles" filter="(member={1})" filter-base-dn="ou=Roles,dc=example,dc=com" role-recursion="2"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <ldap-realm name="KIELdapRealm" dir-context="KIELdapDC">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <identity-mapping rdn-identifier="uid" search-base-dn="ou=Users,dc=example,dc=com" use-recursive-search="true">
-    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" role-mapper="kie-ldap-role-mapper" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <realm name="KIELdapRealm" role-decoder="from-roles-attribute" role-mapper="kie-ldap-logical-default-role-mapper"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security elytron-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <application-security-domain name="other" security-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <constant-role-mapper name="kie-ldap-role-mapper">
@@ -119,7 +121,8 @@ Feature: RHPAM and RHDM common tests
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <attribute from="cn" to="Roles" filter="(member={1})" filter-base-dn="ou=Roles,dc=example,dc=com" role-recursion="100"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <ldap-realm name="KIELdapRealm" dir-context="KIELdapDC">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <identity-mapping rdn-identifier="uid" search-base-dn="ou=Users,dc=example,dc=com">
-    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" role-mapper="kie-ldap-role-mapper" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <realm name="KIELdapRealm" role-decoder="from-roles-attribute" role-mapper="kie-ldap-logical-default-role-mapper"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security elytron-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <application-security-domain name="other" security-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <constant-role-mapper name="kie-ldap-role-mapper">
@@ -147,7 +150,8 @@ Feature: RHPAM and RHDM common tests
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <attribute from="cn" to="Roles" filter="(member={1})" filter-base-dn="ou=Roles,dc=example,dc=com" role-recursion="34"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <ldap-realm name="KIELdapRealm" direct-verification="true" allow-blank-password="true" dir-context="KIELdapDC">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <identity-mapping rdn-identifier="uid" search-base-dn="ou=Users,dc=example,dc=com">
-    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" role-mapper="kie-ldap-role-mapper" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <realm name="KIELdapRealm" role-decoder="from-roles-attribute" role-mapper="kie-ldap-logical-default-role-mapper"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security elytron-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <application-security-domain name="other" security-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <constant-role-mapper name="kie-ldap-role-mapper">
@@ -175,7 +179,8 @@ Feature: RHPAM and RHDM common tests
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <attribute from="cn" to="Roles" filter="(member={1})" filter-base-dn="ou=Roles,dc=example,dc=com" role-recursion="2434"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <ldap-realm name="KIELdapRealm" direct-verification="true" allow-blank-password="true" dir-context="KIELdapDC">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <identity-mapping rdn-identifier="uid" search-base-dn="ou=Users,dc=example,dc=com">
-    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" role-mapper="kie-ldap-role-mapper" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIELdapRealm" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <realm name="KIELdapRealm" role-decoder="from-roles-attribute" role-mapper="kie-ldap-logical-default-role-mapper"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security elytron-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <application-security-domain name="other" security-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <constant-role-mapper name="kie-ldap-role-mapper">
@@ -205,7 +210,8 @@ Feature: RHPAM and RHDM common tests
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <attribute from="cn" to="Roles" filter="(member={1})" filter-base-dn="ou=Roles,dc=example,dc=com" role-recursion="2434"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <ldap-realm name="KIELdapRealm" direct-verification="true" allow-blank-password="true" dir-context="KIELdapDC">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <identity-mapping rdn-identifier="uid" search-base-dn="ou=Users,dc=example,dc=com">
-    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapWithFailOverSecDomain" default-realm="KIEFailOverRealm" role-mapper="kie-ldap-role-mapper" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapWithFailOverSecDomain" default-realm="KIEFailOverRealm" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <realm name="KIEFailOverRealm" role-decoder="kie-aggregate-role-decoder" role-mapper="kie-ldap-logical-default-role-mapper"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security elytron-domain="KIELdapWithFailOverSecDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <application-security-domain name="other" security-domain="KIELdapWithFailOverSecDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <constant-role-mapper name="kie-ldap-role-mapper">
@@ -240,7 +246,8 @@ Feature: RHPAM and RHDM common tests
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <attribute from="cn" to="Roles" filter="(member={1})" filter-base-dn="ou=Roles,dc=example,dc=com" role-recursion="2434"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <ldap-realm name="KIELdapRealm" direct-verification="true" allow-blank-password="true" dir-context="KIELdapDC">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <identity-mapping rdn-identifier="uid" search-base-dn="ou=Users,dc=example,dc=com">
-    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIEDistributedRealm" role-mapper="kie-ldap-role-mapper" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security-domain name="KIELdapSecurityDomain" default-realm="KIEDistributedRealm" permission-mapper="default-permission-mapper">
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <realm name="KIEDistributedRealm" role-decoder="kie-aggregate-role-decoder" role-mapper="kie-ldap-logical-default-role-mapper"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <security elytron-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <application-security-domain name="other" security-domain="KIELdapSecurityDomain"/>
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <constant-role-mapper name="kie-ldap-role-mapper">


### PR DESCRIPTION
… role variable AUTH_LDAP_DEFAULT_ROLE
See: https://issues.redhat.com/browse/RHPAM-4132
Cherry-picks: https://github.com/jboss-container-images/jboss-kie-modules/pull/520

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
