### PR TITLE
[RHPAM-4198] - KieApp deployment with LDAP integration fails when bin…

### DIFF
--- a/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-elytron.bats
+++ b/jboss-kie-wildfly-common/tests/bats/jboss-kie-wildfly-elytron.bats
@@ -361,6 +361,29 @@ teardown() {
 }
 
 
+@test "test elytron ldap configuration dir-context with search limit timeout and referral mode and using special characters on bind credential" {
+    AUTH_LDAP_URL="ldap://test:12345"
+    AUTH_LDAP_BIND_DN="uid=admin,ou=system"
+    AUTH_LDAP_BIND_CREDENTIAL="P&s\$w1'\"ord"
+    AUTH_LDAP_SEARCH_TIME_LIMIT="10000"
+    AUTH_LDAP_REFERRAL_MODE="ignore"
+
+    configure_elytron_ldap_auth
+
+    expected="<dir-contexts>
+                <dir-context name=\"KIELdapDC\" url=\"ldap://test:12345\" read-timeout=\"10000\" referral-mode=\"ignore\" principal=\"uid=admin,ou=system\">
+                    <credential-reference clear-text=\"P&amp;s\$w1'&quot;ord\"/>
+                </dir-context>
+            </dir-contexts>"
+
+    result="$(xmllint --xpath "//*[local-name()='dir-contexts']" $CONFIG_FILE)"
+
+    echo "expected: ${expected}"
+    echo "result  : ${result}"
+    [ "${expected}" = "${result}" ]
+}
+
+
 @test "test elytron ldap configuration dir-context with referral mode" {
     AUTH_LDAP_URL="ldap://test:12345"
     AUTH_LDAP_BIND_DN="uid=admin,ou=system"
@@ -456,7 +479,7 @@ teardown() {
 
 @test "test elytron ldap configuration ldap-realm with identity-mapping and attribute mapping with special characters on baseFilter" {
     AUTH_LDAP_URL="ldap://test:12345"
-    AUTH_LDAP_BASE_FILTER="(&(mail={0}))(|(objectclass=dbperson)(objectclass=inetOrgPerson)))"
+    AUTH_LDAP_BASE_FILTER="(&(mail={0}))(\|(objectclass=dbperson)(objectclass=inetOrgPerson)))"
     AUTH_LDAP_BASE_CTX_DN="ou=people,dc=example,dc=com"
     AUTH_LDAP_ROLE_ATTRIBUTE_ID="cn"
     AUTH_LDAP_ROLE_FILTER="(member={1})"

--- a/tests/features/common/kie-kieserver-common.feature
+++ b/tests/features/common/kie-kieserver-common.feature
@@ -168,25 +168,49 @@ Feature: Kie Server common features
 
   Scenario: Test custom role mapper
     When container is started with env
-      | variable                          | value                         |
-      | AUTH_ROLE_MAPPER_ROLES_PROPERTIES | admin=PowerUser,BillingAdmin  |
+      | variable                           | value                        |
+      | AUTH_LDAP_URL                      | test_url                     |
+      | AUTH_LDAP_BIND_DN                  | cn=Manager,dc=example,dc=com |
+      | AUTH_LDAP_BIND_CREDENTIAL          | admin                        |
+      | AUTH_LDAP_BASE_CTX_DN              | ou=Users,dc=example,dc=com   |
+      | AUTH_LDAP_BASE_FILTER              | uid                          |
+      | AUTH_LDAP_ROLE_ATTRIBUTE_ID        | cn                           |
+      | AUTH_LDAP_ROLES_CTX_DN             | ou=Roles,dc=example,dc=com   |
+      | AUTH_LDAP_ROLE_FILTER              | (member={1})                 |
+      | AUTH_ROLE_MAPPER_ROLES_PROPERTIES  | admin=PowerUser,BillingAdmin |
     Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <mapped-role-mapper name="kie-custom-role-mapper" keep-mapped="false" keep-non-mapped="false">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <role-mapping from="admin" to="PowerUser BillingAdmin"/>
 
   Scenario: Test custom role mapper with mapper keep mapped
     When container is started with env
-      | variable                          | value                         |
-      | AUTH_ROLE_MAPPER_ROLES_PROPERTIES | admin=PowerUser,BillingAdmin  |
-      | AUTH_LDAP_MAPPER_KEEP_MAPPED      | true                          |
+      | variable                          | value                        |
+      | AUTH_LDAP_URL                     | test_url                     |
+      | AUTH_LDAP_BIND_DN                 | cn=Manager,dc=example,dc=com |
+      | AUTH_LDAP_BIND_CREDENTIAL         | admin                        |
+      | AUTH_LDAP_BASE_CTX_DN             | ou=Users,dc=example,dc=com   |
+      | AUTH_LDAP_BASE_FILTER             | uid                          |
+      | AUTH_LDAP_ROLE_ATTRIBUTE_ID       | cn                           |
+      | AUTH_LDAP_ROLES_CTX_DN            | ou=Roles,dc=example,dc=com   |
+      | AUTH_LDAP_ROLE_FILTER             | (member={1})                 |
+      | AUTH_ROLE_MAPPER_ROLES_PROPERTIES | admin=PowerUser,BillingAdmin |
+      | AUTH_LDAP_MAPPER_KEEP_MAPPED      | true                         |
     Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <mapped-role-mapper name="kie-custom-role-mapper" keep-mapped="true" keep-non-mapped="false">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <role-mapping from="admin" to="PowerUser BillingAdmin"/>
 
   Scenario: Test custom role mapper with mapper keep mapped false and non mapped
     When container is started with env
-      | variable                          | value                         |
-      | AUTH_ROLE_MAPPER_ROLES_PROPERTIES | admin=PowerUser,BillingAdmin  |
-      | AUTH_LDAP_MAPPER_KEEP_MAPPED      | false                         |
-      | AUTH_LDAP_MAPPER_KEEP_NON_MAPPED  | true                          |
+      | variable                          | value                        |
+      | AUTH_LDAP_URL                     | test_url                     |
+      | AUTH_LDAP_BIND_DN                 | cn=Manager,dc=example,dc=com |
+      | AUTH_LDAP_BIND_CREDENTIAL         | admin                        |
+      | AUTH_LDAP_BASE_CTX_DN             | ou=Users,dc=example,dc=com   |
+      | AUTH_LDAP_BASE_FILTER             | uid                          |
+      | AUTH_LDAP_ROLE_ATTRIBUTE_ID       | cn                           |
+      | AUTH_LDAP_ROLES_CTX_DN            | ou=Roles,dc=example,dc=com   |
+      | AUTH_LDAP_ROLE_FILTER             | (member={1})                 |
+      | AUTH_ROLE_MAPPER_ROLES_PROPERTIES | admin=PowerUser,BillingAdmin |
+      | AUTH_LDAP_MAPPER_KEEP_MAPPED      | false                        |
+      | AUTH_LDAP_MAPPER_KEEP_NON_MAPPED  | true                         |
     Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <mapped-role-mapper name="kie-custom-role-mapper" keep-mapped="false" keep-non-mapped="true">
     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <role-mapping from="admin" to="PowerUser BillingAdmin"/>
 


### PR DESCRIPTION
…dCredential contains &
See: https://issues.redhat.com/browse/RHPAM-4198

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
