### PR TITLE
RHPAM-3512 - Include missing maven goals on the kieserver-pull.sh script

### DIFF
--- a/jboss-kie-kieserver/added/launch/kieserver-pull.sh
+++ b/jboss-kie-kieserver/added/launch/kieserver-pull.sh
@@ -38,7 +38,7 @@ if [[ "x${KIE_SERVER_CONTAINER_DEPLOYMENT}" != "x" && "${KIE_SERVER_DISABLE_KC_P
         # Add JVM default options
         export MAVEN_OPTS="${MAVEN_OPTS:-$(/opt/run-java/java-default-options)}"
         # Use maven batch mode (CLOUD-579)
-        mavenArgsPull="-e -DskipTests dependency:go-offline -f ${pullPomFile} --batch-mode -Djava.net.preferIPv4Stack=true -Popenshift -Dcom.redhat.xpaas.repo.redhatga ${MAVEN_ARGS_APPEND}"
+        mavenArgsPull="-e -DskipTests dependency:resolve dependency:resolve-plugins dependency:go-offline -f ${pullPomFile} --batch-mode -DincludeScope=test -Djava.net.preferIPv4Stack=true -Popenshift -Dcom.redhat.xpaas.repo.redhatga ${MAVEN_ARGS_APPEND}"
 
         log_info "Attempting to pull dependencies for kjar ${i} with 'mvn ${mavenArgsPull}'"
         log_info "Using MAVEN_OPTS '${MAVEN_OPTS}'"

--- a/jboss-kie-kieserver/added/launch/kieserver-pull.sh
+++ b/jboss-kie-kieserver/added/launch/kieserver-pull.sh
@@ -38,7 +38,7 @@ if [[ "x${KIE_SERVER_CONTAINER_DEPLOYMENT}" != "x" && "${KIE_SERVER_DISABLE_KC_P
         # Add JVM default options
         export MAVEN_OPTS="${MAVEN_OPTS:-$(/opt/run-java/java-default-options)}"
         # Use maven batch mode (CLOUD-579)
-        mavenArgsPull="-e -DskipTests dependency:resolve dependency:resolve-plugins dependency:go-offline -f ${pullPomFile} --batch-mode -DincludeScope=test -Djava.net.preferIPv4Stack=true -Popenshift -Dcom.redhat.xpaas.repo.redhatga ${MAVEN_ARGS_APPEND}"
+        mavenArgsPull="-e dependency:resolve dependency:resolve-plugins dependency:go-offline -f ${pullPomFile} --batch-mode -DincludeScope=test -Djava.net.preferIPv4Stack=true -Popenshift -Dcom.redhat.xpaas.repo.redhatga ${MAVEN_ARGS_APPEND}"
 
         log_info "Attempting to pull dependencies for kjar ${i} with 'mvn ${mavenArgsPull}'"
         log_info "Using MAVEN_OPTS '${MAVEN_OPTS}'"

--- a/jboss-kie-kieserver/added/launch/kieserver-pull.sh
+++ b/jboss-kie-kieserver/added/launch/kieserver-pull.sh
@@ -38,7 +38,7 @@ if [[ "x${KIE_SERVER_CONTAINER_DEPLOYMENT}" != "x" && "${KIE_SERVER_DISABLE_KC_P
         # Add JVM default options
         export MAVEN_OPTS="${MAVEN_OPTS:-$(/opt/run-java/java-default-options)}"
         # Use maven batch mode (CLOUD-579)
-        mavenArgsPull="-e dependency:resolve dependency:resolve-plugins dependency:go-offline -f ${pullPomFile} --batch-mode -DincludeScope=test -Djava.net.preferIPv4Stack=true -Popenshift -Dcom.redhat.xpaas.repo.redhatga ${MAVEN_ARGS_APPEND}"
+        mavenArgsPull="-e -DskipTests dependency:resolve dependency:resolve-plugins dependency:go-offline -f ${pullPomFile} --batch-mode -Djava.net.preferIPv4Stack=true -Popenshift -Dcom.redhat.xpaas.repo.redhatga ${MAVEN_ARGS_APPEND}"
 
         log_info "Attempting to pull dependencies for kjar ${i} with 'mvn ${mavenArgsPull}'"
         log_info "Using MAVEN_OPTS '${MAVEN_OPTS}'"


### PR DESCRIPTION
RHPAM-3512 - Include missing maven goals on the kieserver-pull.sh script
https://issues.redhat.com/browse/RHPAM-3512

Signed-off-by: Achyut Madhusudan <amadhusu@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
