### PR TITLE
[RHPAM-4194] - missing support of KIE_SERVER_BYPASS_AUTH_USER environ…

### DIFF
--- a/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
+++ b/jboss-kie-workbench/added/launch/jboss-kie-workbench.sh
@@ -163,6 +163,11 @@ function configure_server_access() {
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.user=\"$(get_kie_admin_user)\""
         JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.pwd=\"$(esc_kie_admin_pwd)\""
     fi
+
+    local kieServerBypassAuthUser="$(get_kie_server_bypass_auth_user)"
+    if [ "${kieServerBypassAuthUser}" != "" ]; then
+        JBOSS_KIE_ARGS="${JBOSS_KIE_ARGS} -Dorg.kie.server.bypass.auth.user=\"${kieServerBypassAuthUser}\""
+    fi
 }
 
 function configure_openshift_enhancement() {

--- a/jboss-kie-workbench/tests/bats/jboss-kie-workbench.bats
+++ b/jboss-kie-workbench/tests/bats/jboss-kie-workbench.bats
@@ -231,3 +231,37 @@ teardown() {
 
     [ "${JBOSS_KIE_ARGS}" = "${expected}" ]
 }
+
+@test "test if KIE_SERVER_BYPASS_AUTH_USER correctly sets org.kie.server.bypass.auth.user to true" {
+    export KIE_SERVER_BYPASS_AUTH_USER="true"
+
+    expected=" -Dorg.kie.server.user=\"adminUser\" -Dorg.kie.server.pwd=\"admin1!\" -Dorg.kie.server.bypass.auth.user=\"true\""
+    configure_server_access
+
+    echo "Expected: ${expected}"
+    echo "Result  : ${JBOSS_KIE_ARGS}"
+
+    [ "${JBOSS_KIE_ARGS}" = "${expected}" ]
+}
+
+@test "test if KIE_SERVER_BYPASS_AUTH_USER correctly sets org.kie.server.bypass.auth.user to false" {
+    export KIE_SERVER_BYPASS_AUTH_USER="false"
+
+    expected=" -Dorg.kie.server.user=\"adminUser\" -Dorg.kie.server.pwd=\"admin1!\" -Dorg.kie.server.bypass.auth.user=\"false\""
+    configure_server_access
+
+    echo "Expected: ${expected}"
+    echo "Result  : ${JBOSS_KIE_ARGS}"
+
+    [ "${JBOSS_KIE_ARGS}" = "${expected}" ]
+}
+
+@test "test if KIE_SERVER_BYPASS_AUTH_USER when empty does not set org.kie.server.bypass.auth.user" {
+    expected=" -Dorg.kie.server.user=\"adminUser\" -Dorg.kie.server.pwd=\"admin1!\""
+    configure_server_access
+
+    echo "Expected: ${expected}"
+    echo "Result  : ${JBOSS_KIE_ARGS}"
+
+    [ "${JBOSS_KIE_ARGS}" = "${expected}" ]
+}

--- a/tests/features/common/kie-workbench-common.feature
+++ b/tests/features/common/kie-workbench-common.feature
@@ -159,3 +159,9 @@ Feature: Decision/Business Central common features
      And container log should not contain -Dorg.kie.server.controller.user
      And container log should not contain -Dorg.kie.server.controller.pwd
      And container log should contain -Dorg.kie.server.controller.token=some-random-token
+
+  Scenario: Verify the KIE_SERVER_BYPASS_AUTH_USER configuration
+    When container is started with env
+      | variable                    | value    |
+      | KIE_SERVER_BYPASS_AUTH_USER | true     |
+    Then container log should contain -Dorg.kie.server.bypass.auth.user=true


### PR DESCRIPTION
…ment variable in Business central images
See: https://issues.redhat.com/browse/RHPAM-4194

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
