### PR TITLE
[KIECLOUD-667] - Configure kerberos ticket in the existing pipelines

### DIFF
--- a/tools/build-osbs/build-osbs.sh
+++ b/tools/build-osbs/build-osbs.sh
@@ -113,7 +113,7 @@ function get_kerb_ticket() {
     set -e
 }
 
-# _klist will help to indentify if the kerberos ticket, prints when debug is enabled
+# _klist will help to indentify if the kerberos ticket is valid, prints when debug is enabled
 function _klist() {
     if [ -n "$DEBUG" ]; then
         klist
@@ -247,7 +247,7 @@ if [ -n "$KERBEROS_PRINCIPAL" ]; then
     if [ ! -n "$OSBS_BUILD_USER" ]; then
       echo "setting OSBS_BUILD_USER to KERBEROS_PRINCIPAL"
       # need to catch only the first part of the principal, before the / otherwise 'rhpkg' will fail
-      OSBS_BUILD_USER=$(echo ${KERBEROS_PRINCIPAL} | awk -F"/" '{print $1}')
+      OSBS_BUILD_USER=$(echo ${KERBEROS_PRINCIPAL} | awk -F"@" '{print $1}')
     fi
 else
     echo No kerberos principal specified, assuming there is a current kerberos ticket
@@ -270,7 +270,7 @@ if [ -n "$OSBS_BUILD_USER" ]; then
     builduser="$OSBS_BUILD_USER"
 fi
 
-CEKIT_COMMAND="cekit --redhat $debug --work-dir=$cekit_cache_dir build --overrides-file branch-overrides.yaml $overrides $artifactoverrides osbs --user $builduser"
+CEKIT_COMMAND="cekit --redhat $debug --work-dir=$cekit_cache_dir build --overrides-file branch-overrides.yaml $overrides $artifactoverrides osbs --user $builduser -y"
 # Invoke cekit and respond with Y to any prompts
 echo -e "########## Using CeKit version: `cekit --version`.\nExecuting the following CeKit build Command: \n$CEKIT_COMMAND"
 exec $CEKIT_COMMAND


### PR DESCRIPTION
- add cekit osbs -y flag
- if OSBS_BUILD_USER is not set, use the KERBEROS_PRINCIPAL value without the @domain

Signed-off-by: Spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
