### PR TITLE
Add arch and OS in the build instructions

### DIFF
--- a/tools/openshift-template-validator/Makefile
+++ b/tools/openshift-template-validator/Makefile
@@ -6,7 +6,7 @@ SRC_DIR = $(shell pwd)
 VERSION ?= main-$(shell git rev-parse --short=11 HEAD)
 
 build:
-	${GO_EXECUTABLE} build -o openshift-template-validator-linux-amd64 -ldflags "-X main.version=${VERSION}" main.go
+	GOOS=linux GOARCH=amd64 ${GO_EXECUTABLE} build -o openshift-template-validator-linux-amd64 -ldflags "-X main.version=${VERSION}" main.go
 	GOOS=windows GOARCH=amd64 ${GO_EXECUTABLE} build -o openshift-template-validator-amd64.exe -ldflags "-X main.version=${VERSION}" main.go
 	GOOS=darwin GOARCH=arm64 ${GO_EXECUTABLE} build -o openshift-template-validator-arm64 -ldflags "-X main.version=${VERSION}" main.go
 


### PR DESCRIPTION
When building in a different arch the output executable, if not set, inherits the ones from the builder machine.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
