### PR TITLE
[7.13.x-blue][RHPAM-4849] Apply workaround for RHPAM-4849

### DIFF
--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -792,7 +792,7 @@ function configure_server_state() {
         if [ -x "$(command -v java)" ]; then
             java ${JBOSS_KIE_ARGS} $(getKieJavaArgs) ${stateFileInit}
         else
-            log_warning "java symlink in /usr/bin not founded, using JAVA_HOME $JAVA_HOME instead to run verificatoin."
+            log_warning "java symlink in /usr/bin not founded, using JAVA_HOME $JAVA_HOME instead to run verification."
             $JAVA_HOME/bin/java ${JBOSS_KIE_ARGS} $(getKieJavaArgs) ${stateFileInit}
         fi
         ERR=$?

--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -788,7 +788,13 @@ function configure_server_state() {
         # create a KIE server state file with all configured containers and properties
         local stateFileInit="org.kie.server.services.impl.storage.file.KieServerStateFileInit"
         log_info "Attempting to generate kie server state file with 'java ${JBOSS_KIE_ARGS} ${stateFileInit}'"
-        java ${JBOSS_KIE_ARGS} $(getKieJavaArgs) ${stateFileInit}
+        # Workaround for RHPAM-4849
+        if [ -x "$(command -v java)" ]; then
+            java ${JBOSS_KIE_ARGS} $(getKieJavaArgs) ${stateFileInit}
+        else
+            log_warning "java symlink in /usr/bin not founded, using JAVA_HOME $JAVA_HOME instead to run verificatoin."
+            $JAVA_HOME/bin/java ${JBOSS_KIE_ARGS} $(getKieJavaArgs) ${stateFileInit}
+        fi
         ERR=$?
         if [ $ERR -ne 0 ]; then
             log_error "Aborting due to error code $ERR from kie server state file init"

--- a/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
+++ b/jboss-kie-kieserver/added/launch/jboss-kie-kieserver.sh
@@ -792,7 +792,7 @@ function configure_server_state() {
         if [ -x "$(command -v java)" ]; then
             java ${JBOSS_KIE_ARGS} $(getKieJavaArgs) ${stateFileInit}
         else
-            log_warning "java symlink in /usr/bin not founded, using JAVA_HOME $JAVA_HOME instead to run verification."
+            log_warning "java symlink in /usr/bin not found, using JAVA_HOME $JAVA_HOME instead to run verification."
             $JAVA_HOME/bin/java ${JBOSS_KIE_ARGS} $(getKieJavaArgs) ${stateFileInit}
         fi
         ERR=$?

--- a/jboss-kie-kieserver/added/launch/kieserver-verify.sh
+++ b/jboss-kie-kieserver/added/launch/kieserver-verify.sh
@@ -20,7 +20,13 @@ function verifyServerContainers() {
         done
         local containerVerifier="org.kie.server.services.impl.KieServerContainerVerifier"
         log_info "Attempting to verify kie server containers with 'java ${containerVerifier} ${releaseIds}' with custom Java properties '${JAVA_OPTS_APPEND}'"
-        java ${JAVA_OPTS_APPEND} $(getKieJavaArgs) ${containerVerifier} ${releaseIds}
+        # Workaround for RHPAM-4849
+        if [ -x "$(command -v java)" ]; then
+            java ${JAVA_OPTS_APPEND} $(getKieJavaArgs) ${containerVerifier} ${releaseIds}
+        else
+            log_warning "java symlink in /usr/bin not founded, using JAVA_HOME $JAVA_HOME instead to run verificatoin."
+            $JAVA_HOME/bin/java ${JAVA_OPTS_APPEND} $(getKieJavaArgs) ${containerVerifier} ${releaseIds}
+        fi
     fi
 }
 

--- a/jboss-kie-kieserver/added/launch/kieserver-verify.sh
+++ b/jboss-kie-kieserver/added/launch/kieserver-verify.sh
@@ -24,7 +24,7 @@ function verifyServerContainers() {
         if [ -x "$(command -v java)" ]; then
             java ${JAVA_OPTS_APPEND} $(getKieJavaArgs) ${containerVerifier} ${releaseIds}
         else
-            log_warning "java symlink in /usr/bin not founded, using JAVA_HOME $JAVA_HOME instead to run verificatoin."
+            log_warning "java symlink in /usr/bin not founded, using JAVA_HOME $JAVA_HOME instead to run verification."
             $JAVA_HOME/bin/java ${JAVA_OPTS_APPEND} $(getKieJavaArgs) ${containerVerifier} ${releaseIds}
         fi
     fi

--- a/jboss-kie-kieserver/added/launch/kieserver-verify.sh
+++ b/jboss-kie-kieserver/added/launch/kieserver-verify.sh
@@ -24,7 +24,7 @@ function verifyServerContainers() {
         if [ -x "$(command -v java)" ]; then
             java ${JAVA_OPTS_APPEND} $(getKieJavaArgs) ${containerVerifier} ${releaseIds}
         else
-            log_warning "java symlink in /usr/bin not founded, using JAVA_HOME $JAVA_HOME instead to run verification."
+            log_warning "java symlink in /usr/bin not found, using JAVA_HOME $JAVA_HOME instead to run verification."
             $JAVA_HOME/bin/java ${JAVA_OPTS_APPEND} $(getKieJavaArgs) ${containerVerifier} ${releaseIds}
         fi
     fi


### PR DESCRIPTION
Cherry pick of #683

https://issues.redhat.com/browse/RHPAM-4849

Workaround for Kie Server scripts. Kie Server S2I builds failing on missing java symlink.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
