### PR TITLE
Revert "RHPAM-5145- Workaround fix: CVE-2025-58713 /etc/passwd permis…

### DIFF
--- a/os-eap-legacy/os-eap7-launch/added/launch/passwd.sh
+++ b/os-eap-legacy/os-eap7-launch/added/launch/passwd.sh
@@ -7,6 +7,5 @@ function configure() {
 function configure_passwd() {
   sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > /tmp/passwd
   cat /tmp/passwd > /etc/passwd
-  chmod 644 /etc/passwd
   rm /tmp/passwd
 }


### PR DESCRIPTION
…sions change (#702)"

This reverts commit b0c68703b6a57f01cfa19f938cb2a04b7925df2c.

This workaround is applied in different place now.
See https://github.com/jboss-container-images/rhpam-7-image/pull/705

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
